### PR TITLE
feat(users): Day 2 — profile, password, GDPR delete and export endpoints

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -47,15 +47,47 @@ jobs:
         run: npm run format:check
         working-directory: ./Client
 
-  # Optional: Fail the workflow if any checks fail
-  results:
+  test:
     runs-on: ubuntu-latest
     needs: lint-and-format
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js 20.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+
+      - name: Install Server dependencies
+        run: npm install
+        working-directory: ./Server
+
+      - name: Run Server tests with coverage
+        run: npm test -- --coverage --coverageReporters=text --coverageReporters=lcov
+        working-directory: ./Server
+        env:
+          JWT_SECRET: test-jwt-secret-for-ci
+          REFRESH_SECRET: test-refresh-secret-for-ci
+
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: coverage-report
+          path: Server/coverage/lcov-report/
+          retention-days: 14
+
+  # Fail the workflow if any checks fail
+  results:
+    runs-on: ubuntu-latest
+    needs: [lint-and-format, test]
     if: always()
     steps:
       - name: Check workflow status
         run: |
-          if [ "${{ needs.lint-and-format.result }}" != "success" ]; then
+          if [ "${{ needs.lint-and-format.result }}" != "success" ] || [ "${{ needs.test.result }}" != "success" ]; then
             echo "❌ Code quality checks failed!"
             exit 1
           else

--- a/Client/package-lock.json
+++ b/Client/package-lock.json
@@ -1886,9 +1886,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2432,9 +2432,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },
@@ -2980,9 +2980,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.3.tgz",
-      "integrity": "sha512-M2GCs7Vk83NxkUyQV1bkABc4yxgz9kILhHImZiBPAZ9ybuvCb0/H7lEl5XvIg3g+9d4eNotkZA5IWwYl0tibaA==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -3121,9 +3121,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -3479,9 +3479,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.27.0",

--- a/Server/src/__tests__/user.feature.test.js
+++ b/Server/src/__tests__/user.feature.test.js
@@ -1,0 +1,234 @@
+/**
+ * Functional Test Suite — User Account Feature Pathway
+ *
+ * Covers:
+ *   GET    /api/users/me          — get profile
+ *   PATCH  /api/users/me          — update email
+ *   PATCH  /api/users/me/password — change password
+ *   DELETE /api/users/me          — soft-delete account (GDPR erasure)
+ *   GET    /api/users/me/export   — data export (GDPR portability)
+ */
+
+jest.mock('../db/connection');
+jest.mock('bcrypt');
+
+const request = require('supertest');
+const app = require('../app');
+const jwt = require('jsonwebtoken');
+const db = require('../db/connection');
+const bcrypt = require('bcrypt');
+
+beforeAll(() => {
+  process.env.JWT_SECRET = 'test-jwt-secret';
+  process.env.REFRESH_SECRET = 'test-refresh-secret';
+});
+
+beforeEach(() => jest.clearAllMocks());
+
+function makeToken(overrides = {}) {
+  return jwt.sign(
+    { userId: 1, email: 'student@cardiffmet.ac.uk', role: 'user', ...overrides },
+    process.env.JWT_SECRET,
+    { expiresIn: '15m' }
+  );
+}
+
+const MOCK_USER = {
+  id: 1,
+  email: 'student@cardiffmet.ac.uk',
+  role: 'user',
+  created_at: '2026-01-01T00:00:00.000Z',
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GET /api/users/me
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('GET /api/users/me', () => {
+  test('✓ returns profile for authenticated user', async () => {
+    db.query.mockResolvedValueOnce([[MOCK_USER]]);
+
+    const res = await request(app)
+      .get('/api/users/me')
+      .set('Authorization', `Bearer ${makeToken()}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.user.email).toBe('student@cardiffmet.ac.uk');
+    expect(res.body.user).not.toHaveProperty('password');
+  });
+
+  test('✗ returns 401 with no token', async () => {
+    const res = await request(app).get('/api/users/me');
+    expect(res.status).toBe(401);
+  });
+
+  test('✗ returns 404 when user has been soft-deleted', async () => {
+    db.query.mockResolvedValueOnce([[]]); // deleted_at filter returns nothing
+
+    const res = await request(app)
+      .get('/api/users/me')
+      .set('Authorization', `Bearer ${makeToken()}`);
+
+    expect(res.status).toBe(404);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// PATCH /api/users/me
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('PATCH /api/users/me', () => {
+  test('✓ updates email successfully', async () => {
+    db.query
+      .mockResolvedValueOnce([[]]) // no conflict
+      .mockResolvedValueOnce([{ affectedRows: 1 }]) // UPDATE
+      .mockResolvedValueOnce([[{ ...MOCK_USER, email: 'new@cardiffmet.ac.uk' }]]); // refetch
+
+    const res = await request(app)
+      .patch('/api/users/me')
+      .set('Authorization', `Bearer ${makeToken()}`)
+      .send({ email: 'new@cardiffmet.ac.uk' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.message).toBe('Profile updated.');
+    expect(res.body.user.email).toBe('new@cardiffmet.ac.uk');
+  });
+
+  test('✗ rejects invalid email format', async () => {
+    const res = await request(app)
+      .patch('/api/users/me')
+      .set('Authorization', `Bearer ${makeToken()}`)
+      .send({ email: 'not-an-email' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/invalid email/i);
+  });
+
+  test('✗ rejects duplicate email with 409', async () => {
+    db.query.mockResolvedValueOnce([[{ id: 2 }]]); // another user has this email
+
+    const res = await request(app)
+      .patch('/api/users/me')
+      .set('Authorization', `Bearer ${makeToken()}`)
+      .send({ email: 'taken@cardiffmet.ac.uk' });
+
+    expect(res.status).toBe(409);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// PATCH /api/users/me/password
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('PATCH /api/users/me/password', () => {
+  test('✓ changes password with correct current password', async () => {
+    db.query.mockResolvedValueOnce([[{ password: 'hashed-old' }]]);
+    bcrypt.compare.mockResolvedValue(true);
+    bcrypt.hash.mockResolvedValue('hashed-new');
+    db.query.mockResolvedValueOnce([{ affectedRows: 1 }]);
+
+    const res = await request(app)
+      .patch('/api/users/me/password')
+      .set('Authorization', `Bearer ${makeToken()}`)
+      .send({ currentPassword: 'OldPass123', newPassword: 'NewPass456' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.message).toBe('Password updated successfully.');
+  });
+
+  test('✗ rejects wrong current password with 401', async () => {
+    db.query.mockResolvedValueOnce([[{ password: 'hashed-old' }]]);
+    bcrypt.compare.mockResolvedValue(false);
+
+    const res = await request(app)
+      .patch('/api/users/me/password')
+      .set('Authorization', `Bearer ${makeToken()}`)
+      .send({ currentPassword: 'WrongPass', newPassword: 'NewPass456' });
+
+    expect(res.status).toBe(401);
+    expect(res.body.error).toMatch(/incorrect/i);
+  });
+
+  test('✗ rejects new password shorter than 8 characters', async () => {
+    const res = await request(app)
+      .patch('/api/users/me/password')
+      .set('Authorization', `Bearer ${makeToken()}`)
+      .send({ currentPassword: 'OldPass123', newPassword: 'short' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/8 characters/i);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// DELETE /api/users/me  (GDPR Right to Erasure)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('DELETE /api/users/me', () => {
+  test('✓ soft-deletes account after password confirmation', async () => {
+    db.query.mockResolvedValueOnce([[{ password: 'hashed-pass' }]]);
+    bcrypt.compare.mockResolvedValue(true);
+    db.query.mockResolvedValueOnce([{ affectedRows: 1 }]); // soft-delete
+    db.query.mockResolvedValueOnce([{ affectedRows: 3 }]); // anonymise mood logs
+
+    const res = await request(app)
+      .delete('/api/users/me')
+      .set('Authorization', `Bearer ${makeToken()}`)
+      .send({ password: 'CorrectPass123' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.message).toMatch(/deleted/i);
+  });
+
+  test('✗ rejects deletion with wrong password', async () => {
+    db.query.mockResolvedValueOnce([[{ password: 'hashed-pass' }]]);
+    bcrypt.compare.mockResolvedValue(false);
+
+    const res = await request(app)
+      .delete('/api/users/me')
+      .set('Authorization', `Bearer ${makeToken()}`)
+      .send({ password: 'WrongPass' });
+
+    expect(res.status).toBe(401);
+  });
+
+  test('✗ returns 400 when no password provided', async () => {
+    const res = await request(app)
+      .delete('/api/users/me')
+      .set('Authorization', `Bearer ${makeToken()}`)
+      .send({});
+
+    expect(res.status).toBe(400);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GET /api/users/me/export  (GDPR Right to Portability)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('GET /api/users/me/export', () => {
+  test('✓ returns full data export for authenticated user', async () => {
+    db.query
+      .mockResolvedValueOnce([[MOCK_USER]]) // user profile
+      .mockResolvedValueOnce([[{ id: 1, rating: 3, description: 'Okay', logged_at: '2026-01-02' }]]) // mood logs
+      .mockResolvedValueOnce([[]]) // bookings (empty)
+      .mockResolvedValueOnce([[]]); // saved resources (empty)
+
+    const res = await request(app)
+      .get('/api/users/me/export')
+      .set('Authorization', `Bearer ${makeToken()}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('exportedAt');
+    expect(res.body).toHaveProperty('user');
+    expect(res.body).toHaveProperty('mood_logs');
+    expect(res.body).toHaveProperty('bookings');
+    expect(res.body).toHaveProperty('saved_resources');
+    expect(res.body.user).not.toHaveProperty('password');
+  });
+
+  test('✗ returns 401 without auth token', async () => {
+    const res = await request(app).get('/api/users/me/export');
+    expect(res.status).toBe(401);
+  });
+});

--- a/Server/src/app.js
+++ b/Server/src/app.js
@@ -10,6 +10,7 @@ const moodRoutes = require('./routes/mood');
 const resourcesRoutes = require('./routes/resources');
 const bookingRoutes = require('./routes/booking');
 const adminRoutes = require('./routes/admin');
+const userRoutes = require('./routes/users');
 
 const app = express();
 
@@ -37,6 +38,7 @@ app.use('/api/mood', moodRoutes);
 app.use('/api/resources', resourcesRoutes);
 app.use('/api/booking', bookingRoutes);
 app.use('/api/admin', adminRoutes);
+app.use('/api/users', userRoutes);
 
 // 404 handler
 app.use((req, res) => {

--- a/Server/src/controllers/authController.js
+++ b/Server/src/controllers/authController.js
@@ -71,7 +71,10 @@ async function login(req, res) {
   }
 
   try {
-    const [rows] = await db.query('SELECT * FROM users WHERE email = ?', [email]);
+    const [rows] = await db.query(
+      'SELECT * FROM users WHERE email = ? AND deleted_at IS NULL',
+      [email]
+    );
 
     if (rows.length === 0) {
       return res.status(401).json({ error: 'Invalid email or password.' });

--- a/Server/src/controllers/authController.js
+++ b/Server/src/controllers/authController.js
@@ -71,10 +71,9 @@ async function login(req, res) {
   }
 
   try {
-    const [rows] = await db.query(
-      'SELECT * FROM users WHERE email = ? AND deleted_at IS NULL',
-      [email]
-    );
+    const [rows] = await db.query('SELECT * FROM users WHERE email = ? AND deleted_at IS NULL', [
+      email,
+    ]);
 
     if (rows.length === 0) {
       return res.status(401).json({ error: 'Invalid email or password.' });

--- a/Server/src/controllers/userController.js
+++ b/Server/src/controllers/userController.js
@@ -51,10 +51,9 @@ async function updateProfile(req, res) {
       req.user.userId,
     ]);
 
-    const [rows] = await db.query(
-      'SELECT id, email, role, created_at FROM users WHERE id = ?',
-      [req.user.userId]
-    );
+    const [rows] = await db.query('SELECT id, email, role, created_at FROM users WHERE id = ?', [
+      req.user.userId,
+    ]);
 
     res.json({ message: 'Profile updated.', user: rows[0] });
   } catch (err) {
@@ -127,9 +126,7 @@ async function deleteAccount(req, res) {
     await db.query('UPDATE users SET deleted_at = NOW() WHERE id = ?', [req.user.userId]);
 
     // Anonymise mood log descriptions (GDPR — remove personal content)
-    await db.query('UPDATE mood_logs SET description = NULL WHERE user_id = ?', [
-      req.user.userId,
-    ]);
+    await db.query('UPDATE mood_logs SET description = NULL WHERE user_id = ?', [req.user.userId]);
 
     // Clear refresh token cookie
     res.clearCookie('refreshToken');

--- a/Server/src/controllers/userController.js
+++ b/Server/src/controllers/userController.js
@@ -1,0 +1,193 @@
+const bcrypt = require('bcrypt');
+const db = require('../db/connection');
+const { isValidEmail, isValidPassword } = require('../utils/validation');
+
+const SALT_ROUNDS = 10;
+
+// GET /api/users/me
+async function getProfile(req, res) {
+  try {
+    const [rows] = await db.query(
+      'SELECT id, email, role, created_at FROM users WHERE id = ? AND deleted_at IS NULL',
+      [req.user.userId]
+    );
+
+    if (rows.length === 0) {
+      return res.status(404).json({ error: 'User not found.' });
+    }
+
+    res.json({ user: rows[0] });
+  } catch (err) {
+    console.error('Get profile error:', err);
+    res.status(500).json({ error: 'Could not retrieve profile. Please try again.' });
+  }
+}
+
+// PATCH /api/users/me
+async function updateProfile(req, res) {
+  const { email } = req.body;
+
+  if (!email) {
+    return res.status(400).json({ error: 'Email is required.' });
+  }
+
+  if (!isValidEmail(email)) {
+    return res.status(400).json({ error: 'Invalid email format.' });
+  }
+
+  try {
+    // Check email not already taken by another account
+    const [existing] = await db.query(
+      'SELECT id FROM users WHERE email = ? AND id != ? AND deleted_at IS NULL',
+      [email, req.user.userId]
+    );
+
+    if (existing.length > 0) {
+      return res.status(409).json({ error: 'That email is already in use.' });
+    }
+
+    await db.query('UPDATE users SET email = ? WHERE id = ? AND deleted_at IS NULL', [
+      email,
+      req.user.userId,
+    ]);
+
+    const [rows] = await db.query(
+      'SELECT id, email, role, created_at FROM users WHERE id = ?',
+      [req.user.userId]
+    );
+
+    res.json({ message: 'Profile updated.', user: rows[0] });
+  } catch (err) {
+    console.error('Update profile error:', err);
+    res.status(500).json({ error: 'Could not update profile. Please try again.' });
+  }
+}
+
+// PATCH /api/users/me/password
+async function changePassword(req, res) {
+  const { currentPassword, newPassword } = req.body;
+
+  if (!currentPassword || !newPassword) {
+    return res.status(400).json({ error: 'Current password and new password are required.' });
+  }
+
+  if (!isValidPassword(newPassword)) {
+    return res.status(400).json({ error: 'New password must be at least 8 characters.' });
+  }
+
+  try {
+    const [rows] = await db.query(
+      'SELECT password FROM users WHERE id = ? AND deleted_at IS NULL',
+      [req.user.userId]
+    );
+
+    if (rows.length === 0) {
+      return res.status(404).json({ error: 'User not found.' });
+    }
+
+    const match = await bcrypt.compare(currentPassword, rows[0].password);
+    if (!match) {
+      return res.status(401).json({ error: 'Current password is incorrect.' });
+    }
+
+    const hashed = await bcrypt.hash(newPassword, SALT_ROUNDS);
+    await db.query('UPDATE users SET password = ? WHERE id = ?', [hashed, req.user.userId]);
+
+    res.json({ message: 'Password updated successfully.' });
+  } catch (err) {
+    console.error('Change password error:', err);
+    res.status(500).json({ error: 'Could not change password. Please try again.' });
+  }
+}
+
+// DELETE /api/users/me  — GDPR Right to Erasure (soft-delete)
+async function deleteAccount(req, res) {
+  const { password } = req.body;
+
+  if (!password) {
+    return res.status(400).json({ error: 'Password is required to delete your account.' });
+  }
+
+  try {
+    const [rows] = await db.query(
+      'SELECT password FROM users WHERE id = ? AND deleted_at IS NULL',
+      [req.user.userId]
+    );
+
+    if (rows.length === 0) {
+      return res.status(404).json({ error: 'User not found.' });
+    }
+
+    const match = await bcrypt.compare(password, rows[0].password);
+    if (!match) {
+      return res.status(401).json({ error: 'Incorrect password.' });
+    }
+
+    // Soft-delete the user
+    await db.query('UPDATE users SET deleted_at = NOW() WHERE id = ?', [req.user.userId]);
+
+    // Anonymise mood log descriptions (GDPR — remove personal content)
+    await db.query('UPDATE mood_logs SET description = NULL WHERE user_id = ?', [
+      req.user.userId,
+    ]);
+
+    // Clear refresh token cookie
+    res.clearCookie('refreshToken');
+
+    res.json({ message: 'Account deleted. Your data has been anonymised.' });
+  } catch (err) {
+    console.error('Delete account error:', err);
+    res.status(500).json({ error: 'Could not delete account. Please try again.' });
+  }
+}
+
+// GET /api/users/me/export  — GDPR Right to Data Portability
+async function exportData(req, res) {
+  try {
+    const [users] = await db.query(
+      'SELECT id, email, role, created_at FROM users WHERE id = ? AND deleted_at IS NULL',
+      [req.user.userId]
+    );
+
+    if (users.length === 0) {
+      return res.status(404).json({ error: 'User not found.' });
+    }
+
+    const [moodLogs] = await db.query(
+      'SELECT id, rating, description, logged_at FROM mood_logs WHERE user_id = ? ORDER BY logged_at DESC',
+      [req.user.userId]
+    );
+
+    const [bookings] = await db.query(
+      `SELECT b.id, b.status, b.created_at,
+              ts.slot_date, ts.slot_time, ts.time_of_day
+       FROM bookings b
+       JOIN therapy_slots ts ON b.slot_id = ts.id
+       WHERE b.user_id = ?
+       ORDER BY b.created_at DESC`,
+      [req.user.userId]
+    );
+
+    const [savedResources] = await db.query(
+      `SELECT r.id, r.title, r.description, r.url, sr.saved_at
+       FROM saved_resources sr
+       JOIN resources r ON sr.resource_id = r.id
+       WHERE sr.user_id = ?
+       ORDER BY sr.saved_at DESC`,
+      [req.user.userId]
+    );
+
+    res.json({
+      exportedAt: new Date().toISOString(),
+      user: users[0],
+      mood_logs: moodLogs,
+      bookings,
+      saved_resources: savedResources,
+    });
+  } catch (err) {
+    console.error('Export data error:', err);
+    res.status(500).json({ error: 'Could not export data. Please try again.' });
+  }
+}
+
+module.exports = { getProfile, updateProfile, changePassword, deleteAccount, exportData };

--- a/Server/src/routes/admin.js
+++ b/Server/src/routes/admin.js
@@ -4,8 +4,45 @@ const authenticateToken = require('../middleware/auth');
 const requireAdmin = require('../middleware/requireAdmin');
 const db = require('../db/connection');
 
-// GET /api/admin/users
-// Returns a list of all registered users — admin only
+/**
+ * @swagger
+ * /api/admin/users:
+ *   get:
+ *     summary: List all registered users
+ *     description: Returns every user account. Requires admin role.
+ *     tags: [Admin]
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Array of all user accounts
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 users:
+ *                   type: array
+ *                   items:
+ *                     type: object
+ *                     properties:
+ *                       id:
+ *                         type: integer
+ *                         example: 1
+ *                       email:
+ *                         type: string
+ *                         example: student@cardiffmet.ac.uk
+ *                       role:
+ *                         type: string
+ *                         enum: [user, admin]
+ *                       created_at:
+ *                         type: string
+ *                         format: date-time
+ *       401:
+ *         description: No token provided
+ *       403:
+ *         description: Admin role required
+ */
 router.get('/users', authenticateToken, requireAdmin, async (req, res) => {
   try {
     const [users] = await db.query(

--- a/Server/src/routes/users.js
+++ b/Server/src/routes/users.js
@@ -9,10 +9,184 @@ const {
   exportData,
 } = require('../controllers/userController');
 
+/**
+ * @swagger
+ * /api/users/me:
+ *   get:
+ *     summary: Get the authenticated user's profile
+ *     tags: [Account]
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: User profile returned successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 user:
+ *                   type: object
+ *                   properties:
+ *                     id:
+ *                       type: integer
+ *                       example: 1
+ *                     email:
+ *                       type: string
+ *                       example: student@cardiffmet.ac.uk
+ *                     role:
+ *                       type: string
+ *                       enum: [user, admin]
+ *                     created_at:
+ *                       type: string
+ *                       format: date-time
+ *       401:
+ *         description: No token provided
+ *       404:
+ *         description: User not found or account deleted
+ */
 router.get('/me', authenticateToken, getProfile);
+
+/**
+ * @swagger
+ * /api/users/me:
+ *   patch:
+ *     summary: Update the authenticated user's email address
+ *     tags: [Account]
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [email]
+ *             properties:
+ *               email:
+ *                 type: string
+ *                 example: newaddress@cardiffmet.ac.uk
+ *     responses:
+ *       200:
+ *         description: Profile updated, returns updated user object
+ *       400:
+ *         description: Missing or invalid email format
+ *       401:
+ *         description: No token provided
+ *       409:
+ *         description: Email already in use by another account
+ */
 router.patch('/me', authenticateToken, updateProfile);
+
+/**
+ * @swagger
+ * /api/users/me/password:
+ *   patch:
+ *     summary: Change the authenticated user's password
+ *     tags: [Account]
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [currentPassword, newPassword]
+ *             properties:
+ *               currentPassword:
+ *                 type: string
+ *                 example: OldPass123
+ *               newPassword:
+ *                 type: string
+ *                 example: NewPass456
+ *     responses:
+ *       200:
+ *         description: Password changed successfully
+ *       400:
+ *         description: Missing fields or new password too short (min 8 chars)
+ *       401:
+ *         description: Current password is incorrect
+ *       404:
+ *         description: User not found
+ */
 router.patch('/me/password', authenticateToken, changePassword);
+
+/**
+ * @swagger
+ * /api/users/me:
+ *   delete:
+ *     summary: Delete the authenticated user's account (GDPR Right to Erasure)
+ *     description: >
+ *       Soft-deletes the user account and anonymises all mood log descriptions.
+ *       Requires password confirmation. The refresh token cookie is cleared.
+ *     tags: [Account]
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [password]
+ *             properties:
+ *               password:
+ *                 type: string
+ *                 example: MyCurrentPass123
+ *     responses:
+ *       200:
+ *         description: Account soft-deleted and mood log descriptions anonymised
+ *       400:
+ *         description: Password not provided
+ *       401:
+ *         description: Incorrect password
+ *       404:
+ *         description: User not found
+ */
 router.delete('/me', authenticateToken, deleteAccount);
+
+/**
+ * @swagger
+ * /api/users/me/export:
+ *   get:
+ *     summary: Export all personal data as JSON (GDPR Right to Data Portability)
+ *     description: >
+ *       Returns a single JSON object containing the user's profile, all mood log
+ *       entries, therapy bookings, and saved resources.
+ *     tags: [Account]
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Full data export
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 exportedAt:
+ *                   type: string
+ *                   format: date-time
+ *                 user:
+ *                   type: object
+ *                 mood_logs:
+ *                   type: array
+ *                   items:
+ *                     type: object
+ *                 bookings:
+ *                   type: array
+ *                   items:
+ *                     type: object
+ *                 saved_resources:
+ *                   type: array
+ *                   items:
+ *                     type: object
+ *       401:
+ *         description: No token provided
+ *       404:
+ *         description: User not found
+ */
 router.get('/me/export', authenticateToken, exportData);
 
 module.exports = router;

--- a/Server/src/routes/users.js
+++ b/Server/src/routes/users.js
@@ -1,0 +1,18 @@
+const express = require('express');
+const router = express.Router();
+const authenticateToken = require('../middleware/auth');
+const {
+  getProfile,
+  updateProfile,
+  changePassword,
+  deleteAccount,
+  exportData,
+} = require('../controllers/userController');
+
+router.get('/me', authenticateToken, getProfile);
+router.patch('/me', authenticateToken, updateProfile);
+router.patch('/me/password', authenticateToken, changePassword);
+router.delete('/me', authenticateToken, deleteAccount);
+router.get('/me/export', authenticateToken, exportData);
+
+module.exports = router;


### PR DESCRIPTION
## Summary
- Add `GET /api/users/me` — get profile
- Add `PATCH /api/users/me` — update email
- Add `PATCH /api/users/me/password` — change password (requires current)
- Add `DELETE /api/users/me` — soft-delete account + anonymise mood logs (GDPR Right to Erasure)
- Add `GET /api/users/me/export` — full data export JSON (GDPR Right to Portability)
- Fix auth login to filter `deleted_at IS NULL`
- Add Swagger annotations for all Account + Admin endpoints

## Tests
14 new tests — 64/64 passing across 5 suites

## Closes
Day 2 of 3-week plan