### PR TITLE
feat(auth): Day 3 — password reset flow

### DIFF
--- a/Server/src/__tests__/passwordReset.feature.test.js
+++ b/Server/src/__tests__/passwordReset.feature.test.js
@@ -1,0 +1,156 @@
+/**
+ * Functional Test Suite — Password Reset Flow
+ *
+ * Covers:
+ *   POST /api/auth/forgot-password  — request reset token
+ *   POST /api/auth/reset-password   — consume token, set new password
+ *
+ * Security cases tested:
+ *   - Unknown email returns 200 (no enumeration)
+ *   - Expired token rejected
+ *   - Already-used token rejected
+ *   - Invalid token rejected
+ *   - Weak new password rejected
+ */
+
+jest.mock('../db/connection');
+jest.mock('bcrypt');
+
+const request = require('supertest');
+const app = require('../app');
+const db = require('../db/connection');
+const bcrypt = require('bcrypt');
+const crypto = require('crypto');
+
+beforeAll(() => {
+  process.env.JWT_SECRET = 'test-jwt-secret';
+  process.env.REFRESH_SECRET = 'test-refresh-secret';
+});
+
+beforeEach(() => jest.clearAllMocks());
+
+// Helper — build the SHA-256 hash of a plain token (mirrors controller logic)
+function hashToken(token) {
+  return crypto.createHash('sha256').update(token).digest('hex');
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// POST /api/auth/forgot-password
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('POST /api/auth/forgot-password', () => {
+  test('✓ returns 200 and generic message for a registered email', async () => {
+    db.query
+      .mockResolvedValueOnce([[{ id: 1 }]]) // user found
+      .mockResolvedValueOnce([{ affectedRows: 0 }]) // invalidate old tokens
+      .mockResolvedValueOnce([{ insertId: 1 }]); // insert new token
+
+    const res = await request(app)
+      .post('/api/auth/forgot-password')
+      .send({ email: 'student@cardiffmet.ac.uk' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.message).toMatch(/reset link/i);
+  });
+
+  test('✓ returns 200 for an unknown email — no enumeration', async () => {
+    db.query.mockResolvedValueOnce([[]]); // user not found
+
+    const res = await request(app)
+      .post('/api/auth/forgot-password')
+      .send({ email: 'nobody@cardiffmet.ac.uk' });
+
+    // Must still return 200 — attacker cannot tell if email exists
+    expect(res.status).toBe(200);
+    expect(res.body.message).toMatch(/reset link/i);
+  });
+
+  test('✗ returns 400 when email field is missing', async () => {
+    const res = await request(app).post('/api/auth/forgot-password').send({});
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/email is required/i);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// POST /api/auth/reset-password
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('POST /api/auth/reset-password', () => {
+  test('✓ resets password with a valid unexpired token', async () => {
+    const token = 'validtoken123';
+    const futureDate = new Date(Date.now() + 30 * 60 * 1000); // 30 min ahead
+
+    db.query.mockResolvedValueOnce([
+      [{ id: 1, user_id: 1, expires_at: futureDate, used_at: null }],
+    ]);
+    bcrypt.hash.mockResolvedValue('new-hashed-password');
+    db.query.mockResolvedValueOnce([{ affectedRows: 1 }]); // UPDATE users
+    db.query.mockResolvedValueOnce([{ affectedRows: 1 }]); // mark used
+
+    const res = await request(app)
+      .post('/api/auth/reset-password')
+      .send({ token, newPassword: 'NewSecurePass1' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.message).toMatch(/reset successfully/i);
+  });
+
+  test('✗ rejects an invalid (unknown) token', async () => {
+    db.query.mockResolvedValueOnce([[]]); // token hash not found
+
+    const res = await request(app)
+      .post('/api/auth/reset-password')
+      .send({ token: 'made-up-token', newPassword: 'NewSecurePass1' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/invalid or expired/i);
+  });
+
+  test('✗ rejects an expired token', async () => {
+    const token = 'expiredtoken';
+    const pastDate = new Date(Date.now() - 60 * 1000); // 1 min in the past
+
+    db.query.mockResolvedValueOnce([[{ id: 1, user_id: 1, expires_at: pastDate, used_at: null }]]);
+
+    const res = await request(app)
+      .post('/api/auth/reset-password')
+      .send({ token, newPassword: 'NewSecurePass1' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/expired/i);
+  });
+
+  test('✗ rejects a token that has already been used', async () => {
+    const token = 'usedtoken';
+    const futureDate = new Date(Date.now() + 30 * 60 * 1000);
+
+    db.query.mockResolvedValueOnce([
+      [{ id: 1, user_id: 1, expires_at: futureDate, used_at: new Date() }],
+    ]);
+
+    const res = await request(app)
+      .post('/api/auth/reset-password')
+      .send({ token, newPassword: 'NewSecurePass1' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/already been used/i);
+  });
+
+  test('✗ rejects a new password shorter than 8 characters', async () => {
+    const res = await request(app)
+      .post('/api/auth/reset-password')
+      .send({ token: 'sometoken', newPassword: 'short' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/8 characters/i);
+  });
+
+  test('✗ returns 400 when token or newPassword is missing', async () => {
+    const res = await request(app).post('/api/auth/reset-password').send({});
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/required/i);
+  });
+});

--- a/Server/src/__tests__/passwordReset.feature.test.js
+++ b/Server/src/__tests__/passwordReset.feature.test.js
@@ -20,7 +20,6 @@ const request = require('supertest');
 const app = require('../app');
 const db = require('../db/connection');
 const bcrypt = require('bcrypt');
-const crypto = require('crypto');
 
 beforeAll(() => {
   process.env.JWT_SECRET = 'test-jwt-secret';
@@ -28,11 +27,6 @@ beforeAll(() => {
 });
 
 beforeEach(() => jest.clearAllMocks());
-
-// Helper — build the SHA-256 hash of a plain token (mirrors controller logic)
-function hashToken(token) {
-  return crypto.createHash('sha256').update(token).digest('hex');
-}
 
 // ─────────────────────────────────────────────────────────────────────────────
 // POST /api/auth/forgot-password

--- a/Server/src/controllers/passwordResetController.js
+++ b/Server/src/controllers/passwordResetController.js
@@ -1,0 +1,115 @@
+const crypto = require('crypto');
+const bcrypt = require('bcrypt');
+const db = require('../db/connection');
+const { isValidPassword } = require('../utils/validation');
+
+const SALT_ROUNDS = 10;
+const TOKEN_EXPIRY_MINUTES = 30;
+
+// POST /api/auth/forgot-password
+async function forgotPassword(req, res) {
+  const { email } = req.body;
+
+  if (!email) {
+    return res.status(400).json({ error: 'Email is required.' });
+  }
+
+  try {
+    const [rows] = await db.query('SELECT id FROM users WHERE email = ? AND deleted_at IS NULL', [
+      email,
+    ]);
+
+    // Always return 200 — never reveal whether an email exists (prevents enumeration)
+    if (rows.length === 0) {
+      return res.status(200).json({
+        message: 'If that email exists you will receive a reset link shortly.',
+      });
+    }
+
+    const userId = rows[0].id;
+
+    // Invalidate any existing unused tokens for this user
+    await db.query(
+      'UPDATE password_resets SET used_at = NOW() WHERE user_id = ? AND used_at IS NULL',
+      [userId]
+    );
+
+    // Generate a cryptographically secure token
+    const token = crypto.randomBytes(32).toString('hex');
+    const tokenHash = crypto.createHash('sha256').update(token).digest('hex');
+    const expiresAt = new Date(Date.now() + TOKEN_EXPIRY_MINUTES * 60 * 1000);
+
+    await db.query(
+      'INSERT INTO password_resets (user_id, token_hash, expires_at) VALUES (?, ?, ?)',
+      [userId, tokenHash, expiresAt]
+    );
+
+    // In production this would be sent via email (SendGrid / SES).
+    // For demo purposes the reset link is logged to the server console.
+    const resetLink = `${process.env.CLIENT_URL || 'http://localhost:5173'}/reset-password?token=${token}`;
+    console.log(`[PASSWORD RESET] Reset link for ${email}: ${resetLink}`);
+
+    res.status(200).json({
+      message: 'If that email exists you will receive a reset link shortly.',
+    });
+  } catch (err) {
+    console.error('Forgot password error:', err);
+    res.status(500).json({ error: 'Could not process request. Please try again.' });
+  }
+}
+
+// POST /api/auth/reset-password
+async function resetPassword(req, res) {
+  const { token, newPassword } = req.body;
+
+  if (!token || !newPassword) {
+    return res.status(400).json({ error: 'Token and new password are required.' });
+  }
+
+  if (!isValidPassword(newPassword)) {
+    return res.status(400).json({ error: 'Password must be at least 8 characters.' });
+  }
+
+  try {
+    const tokenHash = crypto.createHash('sha256').update(token).digest('hex');
+
+    const [rows] = await db.query(
+      `SELECT pr.id, pr.user_id, pr.expires_at, pr.used_at
+       FROM password_resets pr
+       WHERE pr.token_hash = ?`,
+      [tokenHash]
+    );
+
+    if (rows.length === 0) {
+      return res.status(400).json({ error: 'Invalid or expired reset token.' });
+    }
+
+    const reset = rows[0];
+
+    // Check already used
+    if (reset.used_at !== null) {
+      return res.status(400).json({ error: 'This reset link has already been used.' });
+    }
+
+    // Check expiry
+    if (new Date() > new Date(reset.expires_at)) {
+      return res
+        .status(400)
+        .json({ error: 'This reset link has expired. Please request a new one.' });
+    }
+
+    // Hash new password and update user
+    const hashed = await bcrypt.hash(newPassword, SALT_ROUNDS);
+    await db.query('UPDATE users SET password = ? WHERE id = ?', [hashed, reset.user_id]);
+
+    // Mark token as used
+    await db.query('UPDATE password_resets SET used_at = NOW() WHERE id = ?', [reset.id]);
+
+    res.json({ message: 'Password reset successfully. You can now log in.' });
+  } catch (err) {
+    console.error('Reset password error:', err);
+    res.status(500).json({ error: 'Could not reset password. Please try again.' });
+  }
+}
+
+module.exports = { forgotPassword, resetPassword };

--- a/Server/src/routes/auth.js
+++ b/Server/src/routes/auth.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const router = express.Router();
 const { register, login, refresh, logout } = require('../controllers/authController');
+const { forgotPassword, resetPassword } = require('../controllers/passwordResetController');
 
 /**
  * @swagger
@@ -87,5 +88,62 @@ router.post('/refresh', refresh);
  *         description: Logged out successfully
  */
 router.post('/logout', logout);
+
+/**
+ * @swagger
+ * /api/auth/forgot-password:
+ *   post:
+ *     summary: Request a password reset link
+ *     description: >
+ *       Generates a reset token and logs the link to the server console.
+ *       Always returns 200 to prevent email enumeration.
+ *       In production this would send an email via SendGrid/SES.
+ *     tags: [Auth]
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [email]
+ *             properties:
+ *               email:
+ *                 type: string
+ *                 example: student@cardiffmet.ac.uk
+ *     responses:
+ *       200:
+ *         description: Reset link sent (or silently ignored if email not found)
+ *       400:
+ *         description: Email field missing
+ */
+router.post('/forgot-password', forgotPassword);
+
+/**
+ * @swagger
+ * /api/auth/reset-password:
+ *   post:
+ *     summary: Reset password using a valid token
+ *     tags: [Auth]
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [token, newPassword]
+ *             properties:
+ *               token:
+ *                 type: string
+ *                 example: abc123def456...
+ *               newPassword:
+ *                 type: string
+ *                 example: NewSecurePass1
+ *     responses:
+ *       200:
+ *         description: Password reset successfully
+ *       400:
+ *         description: Missing fields, invalid token, expired token, or token already used
+ */
+router.post('/reset-password', resetPassword);
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- `POST /api/auth/forgot-password` — generates secure token (SHA-256 hashed), logs reset link to console, always returns 200 to prevent email enumeration
- `POST /api/auth/reset-password` — verifies token hash, checks expiry (30 min), rejects reused tokens, updates password

## Security
- Token stored as SHA-256 hash — plain token never persists in DB
- Anti-enumeration: unknown emails return identical 200 response
- Expired and already-used tokens rejected with clear errors

## Tests
9 new tests — 73/73 passing across 6 suites