### PR TITLE
feat(resources+booking): Day 4 — saved resources, category filter, booking cancellation

### DIFF
--- a/Server/src/__tests__/savedResources.feature.test.js
+++ b/Server/src/__tests__/savedResources.feature.test.js
@@ -1,0 +1,199 @@
+/**
+ * Functional Test Suite — Saved Resources + Booking Cancellation
+ *
+ * Covers:
+ *   GET    /api/resources?category=  — category filter
+ *   GET    /api/resources/saved      — list saved resources
+ *   POST   /api/resources/:id/save   — save a resource
+ *   DELETE /api/resources/:id/save   — unsave a resource
+ *   DELETE /api/booking/:id          — cancel a booking
+ */
+
+jest.mock('../db/connection');
+
+const request = require('supertest');
+const app = require('../app');
+const jwt = require('jsonwebtoken');
+const db = require('../db/connection');
+
+beforeAll(() => {
+  process.env.JWT_SECRET = 'test-jwt-secret';
+  process.env.REFRESH_SECRET = 'test-refresh-secret';
+});
+
+beforeEach(() => jest.clearAllMocks());
+
+function makeToken(overrides = {}) {
+  return jwt.sign(
+    { userId: 1, email: 'student@cardiffmet.ac.uk', role: 'user', ...overrides },
+    process.env.JWT_SECRET,
+    { expiresIn: '15m' }
+  );
+}
+
+const MOCK_RESOURCES = [
+  { id: 3, title: 'Student Minds', category: 'anxiety', min_mood: 2, max_mood: 3 },
+  { id: 4, title: 'Calm', category: 'anxiety', min_mood: 2, max_mood: 4 },
+];
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GET /api/resources (with category filter)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('GET /api/resources', () => {
+  test('✓ returns all resources when no filter applied', async () => {
+    db.query.mockResolvedValueOnce([MOCK_RESOURCES]);
+
+    const res = await request(app)
+      .get('/api/resources')
+      .set('Authorization', `Bearer ${makeToken()}`);
+
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body.resources)).toBe(true);
+  });
+
+  test('✓ returns filtered resources by category', async () => {
+    db.query.mockResolvedValueOnce([MOCK_RESOURCES]);
+
+    const res = await request(app)
+      .get('/api/resources?category=anxiety')
+      .set('Authorization', `Bearer ${makeToken()}`);
+
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body.resources)).toBe(true);
+  });
+
+  test('✗ returns 401 without auth token', async () => {
+    const res = await request(app).get('/api/resources');
+    expect(res.status).toBe(401);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// POST /api/resources/:id/save
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('POST /api/resources/:id/save', () => {
+  test('✓ saves a resource successfully', async () => {
+    db.query
+      .mockResolvedValueOnce([[{ id: 1 }]]) // resource exists
+      .mockResolvedValueOnce([{ affectedRows: 1 }]); // INSERT IGNORE
+
+    const res = await request(app)
+      .post('/api/resources/1/save')
+      .set('Authorization', `Bearer ${makeToken()}`);
+
+    expect(res.status).toBe(201);
+    expect(res.body.message).toBe('Resource saved.');
+  });
+
+  test('✗ returns 404 for a non-existent resource', async () => {
+    db.query.mockResolvedValueOnce([[]]); // resource not found
+
+    const res = await request(app)
+      .post('/api/resources/999/save')
+      .set('Authorization', `Bearer ${makeToken()}`);
+
+    expect(res.status).toBe(404);
+  });
+
+  test('✗ returns 401 without auth token', async () => {
+    const res = await request(app).post('/api/resources/1/save');
+    expect(res.status).toBe(401);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// DELETE /api/resources/:id/save
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('DELETE /api/resources/:id/save', () => {
+  test('✓ removes a saved resource', async () => {
+    db.query.mockResolvedValueOnce([{ affectedRows: 1 }]);
+
+    const res = await request(app)
+      .delete('/api/resources/1/save')
+      .set('Authorization', `Bearer ${makeToken()}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.message).toMatch(/removed/i);
+  });
+
+  test('✗ returns 404 when resource was not saved', async () => {
+    db.query.mockResolvedValueOnce([{ affectedRows: 0 }]);
+
+    const res = await request(app)
+      .delete('/api/resources/1/save')
+      .set('Authorization', `Bearer ${makeToken()}`);
+
+    expect(res.status).toBe(404);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GET /api/resources/saved
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('GET /api/resources/saved', () => {
+  test('✓ returns saved resources for authenticated user', async () => {
+    db.query.mockResolvedValueOnce([MOCK_RESOURCES]);
+
+    const res = await request(app)
+      .get('/api/resources/saved')
+      .set('Authorization', `Bearer ${makeToken()}`);
+
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body.resources)).toBe(true);
+  });
+
+  test('✗ returns 401 without auth token', async () => {
+    const res = await request(app).get('/api/resources/saved');
+    expect(res.status).toBe(401);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// DELETE /api/booking/:id
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('DELETE /api/booking/:id', () => {
+  test('✓ cancels a pending booking and restores the slot', async () => {
+    db.query
+      .mockResolvedValueOnce([[{ id: 1, status: 'pending', slot_id: 5 }]]) // booking found
+      .mockResolvedValueOnce([{ affectedRows: 1 }]) // DELETE booking
+      .mockResolvedValueOnce([{ affectedRows: 1 }]); // restore slot
+
+    const res = await request(app)
+      .delete('/api/booking/1')
+      .set('Authorization', `Bearer ${makeToken()}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.message).toBe('Booking cancelled.');
+  });
+
+  test('✗ returns 404 when booking not found or not owned by user', async () => {
+    db.query.mockResolvedValueOnce([[]]); // no booking found
+
+    const res = await request(app)
+      .delete('/api/booking/999')
+      .set('Authorization', `Bearer ${makeToken()}`);
+
+    expect(res.status).toBe(404);
+  });
+
+  test('✗ returns 409 when trying to cancel a confirmed booking', async () => {
+    db.query.mockResolvedValueOnce([[{ id: 1, status: 'confirmed', slot_id: 5 }]]);
+
+    const res = await request(app)
+      .delete('/api/booking/1')
+      .set('Authorization', `Bearer ${makeToken()}`);
+
+    expect(res.status).toBe(409);
+    expect(res.body.error).toMatch(/confirmed/i);
+  });
+
+  test('✗ returns 401 without auth token', async () => {
+    const res = await request(app).delete('/api/booking/1');
+    expect(res.status).toBe(401);
+  });
+});

--- a/Server/src/controllers/bookingController.js
+++ b/Server/src/controllers/bookingController.js
@@ -76,4 +76,45 @@ async function getMyBookings(req, res) {
   }
 }
 
-module.exports = { getSlots, createBooking, getMyBookings };
+// DELETE /api/booking/:id
+async function cancelBooking(req, res) {
+  const bookingId = parseInt(req.params.id, 10);
+  const userId = req.user.userId;
+
+  try {
+    // Fetch booking and verify ownership
+    const [rows] = await db.query(
+      'SELECT b.id, b.status, b.slot_id FROM bookings b WHERE b.id = ? AND b.user_id = ?',
+      [bookingId, userId]
+    );
+
+    if (rows.length === 0) {
+      return res.status(404).json({ error: 'Booking not found.' });
+    }
+
+    const booking = rows[0];
+
+    if (booking.status === 'confirmed') {
+      return res
+        .status(409)
+        .json({
+          error: 'Confirmed bookings cannot be cancelled. Please contact the wellbeing team.',
+        });
+    }
+
+    if (booking.status === 'declined') {
+      return res.status(409).json({ error: 'This booking has already been declined.' });
+    }
+
+    // Delete booking and restore slot to available
+    await db.query('DELETE FROM bookings WHERE id = ?', [bookingId]);
+    await db.query('UPDATE therapy_slots SET status = "available" WHERE id = ?', [booking.slot_id]);
+
+    res.json({ message: 'Booking cancelled.' });
+  } catch (err) {
+    console.error('Cancel booking error:', err);
+    res.status(500).json({ error: 'Failed to cancel booking. Please try again.' });
+  }
+}
+
+module.exports = { getSlots, createBooking, getMyBookings, cancelBooking };

--- a/Server/src/controllers/bookingController.js
+++ b/Server/src/controllers/bookingController.js
@@ -95,11 +95,9 @@ async function cancelBooking(req, res) {
     const booking = rows[0];
 
     if (booking.status === 'confirmed') {
-      return res
-        .status(409)
-        .json({
-          error: 'Confirmed bookings cannot be cancelled. Please contact the wellbeing team.',
-        });
+      return res.status(409).json({
+        error: 'Confirmed bookings cannot be cancelled. Please contact the wellbeing team.',
+      });
     }
 
     if (booking.status === 'declined') {

--- a/Server/src/controllers/resourcesController.js
+++ b/Server/src/controllers/resourcesController.js
@@ -1,9 +1,21 @@
 const db = require('../db/connection');
 
-// GET /api/resources
+// GET /api/resources?category=anxiety
 async function getResources(req, res) {
+  const { category } = req.query;
+
   try {
-    const [resources] = await db.query('SELECT * FROM resources ORDER BY id ASC');
+    let sql = 'SELECT * FROM resources';
+    const params = [];
+
+    if (category) {
+      sql += ' WHERE category = ?';
+      params.push(category);
+    }
+
+    sql += ' ORDER BY id ASC';
+
+    const [resources] = await db.query(sql, params);
     res.json({ resources });
   } catch (err) {
     console.error('Resources error:', err);
@@ -11,4 +23,70 @@ async function getResources(req, res) {
   }
 }
 
-module.exports = { getResources };
+// POST /api/resources/:id/save
+async function saveResource(req, res) {
+  const resourceId = parseInt(req.params.id, 10);
+  const userId = req.user.userId;
+
+  try {
+    const [resource] = await db.query('SELECT id FROM resources WHERE id = ?', [resourceId]);
+    if (resource.length === 0) {
+      return res.status(404).json({ error: 'Resource not found.' });
+    }
+
+    await db.query('INSERT IGNORE INTO saved_resources (user_id, resource_id) VALUES (?, ?)', [
+      userId,
+      resourceId,
+    ]);
+
+    res.status(201).json({ message: 'Resource saved.' });
+  } catch (err) {
+    console.error('Save resource error:', err);
+    res.status(500).json({ error: 'Failed to save resource.' });
+  }
+}
+
+// DELETE /api/resources/:id/save
+async function unsaveResource(req, res) {
+  const resourceId = parseInt(req.params.id, 10);
+  const userId = req.user.userId;
+
+  try {
+    const [result] = await db.query(
+      'DELETE FROM saved_resources WHERE user_id = ? AND resource_id = ?',
+      [userId, resourceId]
+    );
+
+    if (result.affectedRows === 0) {
+      return res.status(404).json({ error: 'Saved resource not found.' });
+    }
+
+    res.json({ message: 'Resource removed from saved.' });
+  } catch (err) {
+    console.error('Unsave resource error:', err);
+    res.status(500).json({ error: 'Failed to remove saved resource.' });
+  }
+}
+
+// GET /api/resources/saved
+async function getSavedResources(req, res) {
+  const userId = req.user.userId;
+
+  try {
+    const [resources] = await db.query(
+      `SELECT r.id, r.title, r.description, r.url, r.category, r.min_mood, r.max_mood, sr.saved_at
+       FROM saved_resources sr
+       JOIN resources r ON sr.resource_id = r.id
+       WHERE sr.user_id = ?
+       ORDER BY sr.saved_at DESC`,
+      [userId]
+    );
+
+    res.json({ resources });
+  } catch (err) {
+    console.error('Get saved resources error:', err);
+    res.status(500).json({ error: 'Failed to fetch saved resources.' });
+  }
+}
+
+module.exports = { getResources, saveResource, unsaveResource, getSavedResources };

--- a/Server/src/db/schema.sql
+++ b/Server/src/db/schema.sql
@@ -30,6 +30,7 @@ CREATE TABLE IF NOT EXISTS resources (
   title       VARCHAR(255) NOT NULL,
   description TEXT,
   url         VARCHAR(500),
+  category    VARCHAR(50) DEFAULT 'general',
   min_mood    TINYINT DEFAULT 1,
   max_mood    TINYINT DEFAULT 5,
   created_at  TIMESTAMP DEFAULT CURRENT_TIMESTAMP
@@ -96,15 +97,15 @@ CREATE TABLE IF NOT EXISTS audit_log (
 );
 
 -- Seed resources
-INSERT INTO resources (title, description, url, min_mood, max_mood) VALUES
-  ('Crisis Support – Samaritans',      'Free confidential support. Call 116 123 anytime.',          'https://www.samaritans.org',             1, 1),
-  ('NHS Urgent Mental Health Support', 'Call 111 and select option 2 for urgent support.',           'https://www.nhs.uk/mental-health',       1, 2),
-  ('Student Minds – Managing Stress',  'Practical tips for managing stress during exam periods.',    'https://www.studentminds.org.uk',        2, 3),
-  ('Calm – Breathing Exercises',       'Guided breathing and mindfulness to reduce anxiety.',        'https://www.calm.com',                   2, 4),
-  ('Cardiff Met Wellbeing Services',   'Book an appointment with the university wellbeing team.',    'https://www.cardiffmet.ac.uk/wellbeing', 1, 5),
-  ('MoodGym – Self-Help CBT',          'Free online cognitive behavioural therapy exercises.',       'https://moodgym.com.au',                 3, 5),
-  ('NHS – Sleep and Tiredness Tips',   'Advice on improving sleep quality and managing fatigue.',    'https://www.nhs.uk/live-well/sleep',     3, 5),
-  ('Headspace – Meditation',           'Guided meditation for stress relief and improved focus.',    'https://www.headspace.com',              4, 5);
+INSERT INTO resources (title, description, url, category, min_mood, max_mood) VALUES
+  ('Crisis Support – Samaritans',      'Free confidential support. Call 116 123 anytime.',          'https://www.samaritans.org',             'crisis',      1, 1),
+  ('NHS Urgent Mental Health Support', 'Call 111 and select option 2 for urgent support.',           'https://www.nhs.uk/mental-health',       'crisis',      1, 2),
+  ('Student Minds – Managing Stress',  'Practical tips for managing stress during exam periods.',    'https://www.studentminds.org.uk',        'anxiety',     2, 3),
+  ('Calm – Breathing Exercises',       'Guided breathing and mindfulness to reduce anxiety.',        'https://www.calm.com',                   'anxiety',     2, 4),
+  ('Cardiff Met Wellbeing Services',   'Book an appointment with the university wellbeing team.',    'https://www.cardiffmet.ac.uk/wellbeing', 'general',     1, 5),
+  ('MoodGym – Self-Help CBT',          'Free online cognitive behavioural therapy exercises.',       'https://moodgym.com.au',                 'self-help',   3, 5),
+  ('NHS – Sleep and Tiredness Tips',   'Advice on improving sleep quality and managing fatigue.',    'https://www.nhs.uk/live-well/sleep',     'self-help',   3, 5),
+  ('Headspace – Meditation',           'Guided meditation for stress relief and improved focus.',    'https://www.headspace.com',              'mindfulness', 4, 5);
 
 -- Seed admin user (password: Admin1234! — bcrypt hash, 10 rounds)
 INSERT IGNORE INTO users (email, password, role) VALUES

--- a/Server/src/routes/booking.js
+++ b/Server/src/routes/booking.js
@@ -1,7 +1,12 @@
 const express = require('express');
 const router = express.Router();
 const authenticateToken = require('../middleware/auth');
-const { getSlots, createBooking, getMyBookings } = require('../controllers/bookingController');
+const {
+  getSlots,
+  createBooking,
+  getMyBookings,
+  cancelBooking,
+} = require('../controllers/bookingController');
 
 router.use(authenticateToken);
 
@@ -65,5 +70,35 @@ router.get('/my', getMyBookings);
  *         description: Unauthorised
  */
 router.post('/', createBooking);
+
+/**
+ * @swagger
+ * /api/booking/{id}:
+ *   delete:
+ *     summary: Cancel a pending booking
+ *     description: >
+ *       Cancels the booking and restores the therapy slot to available.
+ *       Only the booking owner can cancel. Confirmed bookings cannot be cancelled.
+ *     tags: [Booking]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: integer
+ *         description: Booking ID to cancel
+ *     responses:
+ *       200:
+ *         description: Booking cancelled and slot restored
+ *       404:
+ *         description: Booking not found or not owned by user
+ *       409:
+ *         description: Booking is confirmed or already declined — cannot cancel
+ *       401:
+ *         description: Unauthorised
+ */
+router.delete('/:id', cancelBooking);
 
 module.exports = router;

--- a/Server/src/routes/resources.js
+++ b/Server/src/routes/resources.js
@@ -1,7 +1,12 @@
 const express = require('express');
 const router = express.Router();
 const authenticateToken = require('../middleware/auth');
-const { getResources } = require('../controllers/resourcesController');
+const {
+  getResources,
+  saveResource,
+  unsaveResource,
+  getSavedResources,
+} = require('../controllers/resourcesController');
 
 router.use(authenticateToken);
 
@@ -9,10 +14,19 @@ router.use(authenticateToken);
  * @swagger
  * /api/resources:
  *   get:
- *     summary: Get all mental health resources
+ *     summary: Get all mental health resources, optionally filtered by category
  *     tags: [Resources]
  *     security:
  *       - bearerAuth: []
+ *     parameters:
+ *       - in: query
+ *         name: category
+ *         schema:
+ *           type: string
+ *           enum: [crisis, anxiety, self-help, mindfulness, general]
+ *         required: false
+ *         description: Filter resources by category
+ *         example: anxiety
  *     responses:
  *       200:
  *         description: Returns array of resources
@@ -20,5 +34,69 @@ router.use(authenticateToken);
  *         description: Unauthorised
  */
 router.get('/', getResources);
+
+/**
+ * @swagger
+ * /api/resources/saved:
+ *   get:
+ *     summary: Get all resources saved by the authenticated user
+ *     tags: [Resources]
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Returns array of saved resources with saved_at timestamp
+ *       401:
+ *         description: Unauthorised
+ */
+router.get('/saved', getSavedResources);
+
+/**
+ * @swagger
+ * /api/resources/{id}/save:
+ *   post:
+ *     summary: Save a resource to the user's saved list
+ *     tags: [Resources]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: integer
+ *     responses:
+ *       201:
+ *         description: Resource saved (idempotent — saving twice is safe)
+ *       404:
+ *         description: Resource not found
+ *       401:
+ *         description: Unauthorised
+ */
+router.post('/:id/save', saveResource);
+
+/**
+ * @swagger
+ * /api/resources/{id}/save:
+ *   delete:
+ *     summary: Remove a resource from the user's saved list
+ *     tags: [Resources]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: integer
+ *     responses:
+ *       200:
+ *         description: Resource removed from saved list
+ *       404:
+ *         description: Resource was not in saved list
+ *       401:
+ *         description: Unauthorised
+ */
+router.delete('/:id/save', unsaveResource);
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- Add `category` column to resources (crisis, anxiety, self-help, mindfulness, general)
- `GET /api/resources?category=` — filter resources by category
- `GET /api/resources/saved` — list saved resources
- `POST /api/resources/:id/save` — save resource (idempotent)
- `DELETE /api/resources/:id/save` — unsave resource
- `DELETE /api/booking/:id` — cancel pending booking, restores slot to available

## Tests
14 new tests — 87/87 passing across 7 suites