### PR TITLE
feat: Day 6 — Admin API

### DIFF
--- a/Server/src/__tests__/admin.feature.test.js
+++ b/Server/src/__tests__/admin.feature.test.js
@@ -1,0 +1,334 @@
+/**
+ * Functional Test Suite — Admin API
+ *
+ * Covers:
+ *   GET    /api/admin/users          — list all users
+ *   GET    /api/admin/resources      — list all resources
+ *   POST   /api/admin/resources      — create resource
+ *   PATCH  /api/admin/resources/:id  — update resource
+ *   DELETE /api/admin/resources/:id  — delete resource
+ *   GET    /api/admin/bookings       — list all bookings
+ *   PATCH  /api/admin/bookings/:id   — confirm / decline booking
+ *
+ * All endpoints require admin role — 403 tests for regular users are included.
+ */
+
+jest.mock('../db/connection');
+
+const request = require('supertest');
+const app = require('../app');
+const jwt = require('jsonwebtoken');
+const db = require('../db/connection');
+
+beforeAll(() => {
+  process.env.JWT_SECRET = 'ci-jwt-secret-value-that-is-long-enough-here';
+  process.env.REFRESH_SECRET = 'ci-refresh-secret-value-that-is-long-enough';
+  process.env.NODE_ENV = 'test';
+});
+
+beforeEach(() => jest.clearAllMocks());
+
+function makeToken(overrides = {}) {
+  return jwt.sign(
+    { userId: 1, email: 'admin@cardiffmet.ac.uk', role: 'admin', ...overrides },
+    process.env.JWT_SECRET,
+    { expiresIn: '15m' }
+  );
+}
+
+const adminToken = () => makeToken({ role: 'admin' });
+const userToken = () => makeToken({ role: 'user' });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GET /api/admin/users
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('GET /api/admin/users', () => {
+  test('✓ returns all users for admin', async () => {
+    db.query.mockResolvedValueOnce([
+      [
+        { id: 1, email: 'admin@cardiffmet.ac.uk', role: 'admin', created_at: new Date() },
+        { id: 2, email: 'student@cardiffmet.ac.uk', role: 'user', created_at: new Date() },
+      ],
+    ]);
+
+    const res = await request(app)
+      .get('/api/admin/users')
+      .set('Authorization', `Bearer ${adminToken()}`);
+
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body.users)).toBe(true);
+    expect(res.body.users).toHaveLength(2);
+  });
+
+  test('✗ returns 403 for non-admin user', async () => {
+    const res = await request(app)
+      .get('/api/admin/users')
+      .set('Authorization', `Bearer ${userToken()}`);
+
+    expect(res.status).toBe(403);
+  });
+
+  test('✗ returns 401 without token', async () => {
+    const res = await request(app).get('/api/admin/users');
+    expect(res.status).toBe(401);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GET /api/admin/resources
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('GET /api/admin/resources', () => {
+  test('✓ returns all resources for admin', async () => {
+    db.query.mockResolvedValueOnce([
+      [
+        { id: 1, title: 'Breathing exercises', category: 'anxiety' },
+        { id: 2, title: 'Crisis line', category: 'crisis' },
+      ],
+    ]);
+
+    const res = await request(app)
+      .get('/api/admin/resources')
+      .set('Authorization', `Bearer ${adminToken()}`);
+
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body.resources)).toBe(true);
+  });
+
+  test('✗ returns 403 for non-admin user', async () => {
+    const res = await request(app)
+      .get('/api/admin/resources')
+      .set('Authorization', `Bearer ${userToken()}`);
+
+    expect(res.status).toBe(403);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// POST /api/admin/resources
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('POST /api/admin/resources', () => {
+  test('✓ creates a resource and returns 201', async () => {
+    db.query.mockResolvedValueOnce([{ insertId: 10 }]);
+
+    const res = await request(app)
+      .post('/api/admin/resources')
+      .set('Authorization', `Bearer ${adminToken()}`)
+      .send({ title: 'New Resource', url: 'https://example.com', category: 'general' });
+
+    expect(res.status).toBe(201);
+    expect(res.body.message).toBe('Resource created.');
+    expect(res.body.resourceId).toBe(10);
+  });
+
+  test('✗ returns 400 when required fields are missing', async () => {
+    const res = await request(app)
+      .post('/api/admin/resources')
+      .set('Authorization', `Bearer ${adminToken()}`)
+      .send({ title: 'Missing url and category' });
+
+    expect(res.status).toBe(400);
+  });
+
+  test('✗ returns 403 for non-admin user', async () => {
+    const res = await request(app)
+      .post('/api/admin/resources')
+      .set('Authorization', `Bearer ${userToken()}`)
+      .send({ title: 'Test', url: 'https://example.com', category: 'general' });
+
+    expect(res.status).toBe(403);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// PATCH /api/admin/resources/:id
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('PATCH /api/admin/resources/:id', () => {
+  test('✓ updates a resource', async () => {
+    db.query
+      .mockResolvedValueOnce([[{ id: 1 }]]) // resource exists
+      .mockResolvedValueOnce([{ affectedRows: 1 }]); // UPDATE
+
+    const res = await request(app)
+      .patch('/api/admin/resources/1')
+      .set('Authorization', `Bearer ${adminToken()}`)
+      .send({ title: 'Updated Title' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.message).toBe('Resource updated.');
+  });
+
+  test('✗ returns 404 for non-existent resource', async () => {
+    db.query.mockResolvedValueOnce([[]]); // not found
+
+    const res = await request(app)
+      .patch('/api/admin/resources/999')
+      .set('Authorization', `Bearer ${adminToken()}`)
+      .send({ title: 'Updated' });
+
+    expect(res.status).toBe(404);
+  });
+
+  test('✗ returns 403 for non-admin user', async () => {
+    const res = await request(app)
+      .patch('/api/admin/resources/1')
+      .set('Authorization', `Bearer ${userToken()}`)
+      .send({ title: 'Updated' });
+
+    expect(res.status).toBe(403);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// DELETE /api/admin/resources/:id
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('DELETE /api/admin/resources/:id', () => {
+  test('✓ deletes a resource', async () => {
+    db.query
+      .mockResolvedValueOnce([[{ id: 1 }]]) // resource exists
+      .mockResolvedValueOnce([{ affectedRows: 1 }]); // DELETE
+
+    const res = await request(app)
+      .delete('/api/admin/resources/1')
+      .set('Authorization', `Bearer ${adminToken()}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.message).toBe('Resource deleted.');
+  });
+
+  test('✗ returns 404 for non-existent resource', async () => {
+    db.query.mockResolvedValueOnce([[]]); // not found
+
+    const res = await request(app)
+      .delete('/api/admin/resources/999')
+      .set('Authorization', `Bearer ${adminToken()}`);
+
+    expect(res.status).toBe(404);
+  });
+
+  test('✗ returns 403 for non-admin user', async () => {
+    const res = await request(app)
+      .delete('/api/admin/resources/1')
+      .set('Authorization', `Bearer ${userToken()}`);
+
+    expect(res.status).toBe(403);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GET /api/admin/bookings
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('GET /api/admin/bookings', () => {
+  test('✓ returns all bookings with user and slot details', async () => {
+    db.query.mockResolvedValueOnce([
+      [
+        {
+          id: 1,
+          status: 'pending',
+          user_email: 'student@cardiffmet.ac.uk',
+          slot_date: '2025-06-01',
+          slot_time: '10:00:00',
+          time_of_day: 'morning',
+          created_at: new Date(),
+        },
+      ],
+    ]);
+
+    const res = await request(app)
+      .get('/api/admin/bookings')
+      .set('Authorization', `Bearer ${adminToken()}`);
+
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body.bookings)).toBe(true);
+  });
+
+  test('✗ returns 403 for non-admin user', async () => {
+    const res = await request(app)
+      .get('/api/admin/bookings')
+      .set('Authorization', `Bearer ${userToken()}`);
+
+    expect(res.status).toBe(403);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// PATCH /api/admin/bookings/:id
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('PATCH /api/admin/bookings/:id', () => {
+  test('✓ confirms a pending booking and marks slot as booked', async () => {
+    db.query
+      .mockResolvedValueOnce([[{ id: 1, status: 'pending', slot_id: 5 }]]) // booking found
+      .mockResolvedValueOnce([{ affectedRows: 1 }]) // UPDATE bookings
+      .mockResolvedValueOnce([{ affectedRows: 1 }]); // UPDATE therapy_slots
+
+    const res = await request(app)
+      .patch('/api/admin/bookings/1')
+      .set('Authorization', `Bearer ${adminToken()}`)
+      .send({ status: 'confirmed' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.message).toBe('Booking confirmed.');
+  });
+
+  test('✓ declines a pending booking and restores slot', async () => {
+    db.query
+      .mockResolvedValueOnce([[{ id: 1, status: 'pending', slot_id: 5 }]])
+      .mockResolvedValueOnce([{ affectedRows: 1 }])
+      .mockResolvedValueOnce([{ affectedRows: 1 }]);
+
+    const res = await request(app)
+      .patch('/api/admin/bookings/1')
+      .set('Authorization', `Bearer ${adminToken()}`)
+      .send({ status: 'declined' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.message).toBe('Booking declined.');
+  });
+
+  test('✗ returns 400 for invalid status value', async () => {
+    const res = await request(app)
+      .patch('/api/admin/bookings/1')
+      .set('Authorization', `Bearer ${adminToken()}`)
+      .send({ status: 'cancelled' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/confirmed.*declined|declined.*confirmed/i);
+  });
+
+  test('✗ returns 404 when booking not found', async () => {
+    db.query.mockResolvedValueOnce([[]]); // not found
+
+    const res = await request(app)
+      .patch('/api/admin/bookings/999')
+      .set('Authorization', `Bearer ${adminToken()}`)
+      .send({ status: 'confirmed' });
+
+    expect(res.status).toBe(404);
+  });
+
+  test('✗ returns 409 when booking is already confirmed', async () => {
+    db.query.mockResolvedValueOnce([[{ id: 1, status: 'confirmed', slot_id: 5 }]]);
+
+    const res = await request(app)
+      .patch('/api/admin/bookings/1')
+      .set('Authorization', `Bearer ${adminToken()}`)
+      .send({ status: 'confirmed' });
+
+    expect(res.status).toBe(409);
+  });
+
+  test('✗ returns 403 for non-admin user', async () => {
+    const res = await request(app)
+      .patch('/api/admin/bookings/1')
+      .set('Authorization', `Bearer ${userToken()}`)
+      .send({ status: 'confirmed' });
+
+    expect(res.status).toBe(403);
+  });
+});

--- a/Server/src/controllers/adminController.js
+++ b/Server/src/controllers/adminController.js
@@ -1,0 +1,176 @@
+const db = require('../db/connection');
+
+// GET /api/admin/users
+async function listUsers(req, res) {
+  try {
+    const [users] = await db.query(
+      'SELECT id, email, role, created_at, deleted_at FROM users ORDER BY created_at DESC'
+    );
+    res.json({ users });
+  } catch (err) {
+    console.error('Admin list users error:', err);
+    res.status(500).json({ error: 'Failed to fetch users.' });
+  }
+}
+
+// GET /api/admin/resources
+async function listResources(req, res) {
+  try {
+    const [resources] = await db.query('SELECT * FROM resources ORDER BY id ASC');
+    res.json({ resources });
+  } catch (err) {
+    console.error('Admin list resources error:', err);
+    res.status(500).json({ error: 'Failed to fetch resources.' });
+  }
+}
+
+// POST /api/admin/resources
+async function createResource(req, res) {
+  const { title, description, url, category, min_mood, max_mood } = req.body;
+
+  if (!title || !url || !category) {
+    return res.status(400).json({ error: 'title, url, and category are required.' });
+  }
+
+  try {
+    const [result] = await db.query(
+      'INSERT INTO resources (title, description, url, category, min_mood, max_mood) VALUES (?, ?, ?, ?, ?, ?)',
+      [title, description || null, url, category, min_mood ?? 1, max_mood ?? 5]
+    );
+    res.status(201).json({ message: 'Resource created.', resourceId: result.insertId });
+  } catch (err) {
+    console.error('Admin create resource error:', err);
+    res.status(500).json({ error: 'Failed to create resource.' });
+  }
+}
+
+// PATCH /api/admin/resources/:id
+async function updateResource(req, res) {
+  const resourceId = parseInt(req.params.id, 10);
+  const { title, description, url, category, min_mood, max_mood } = req.body;
+
+  try {
+    const [rows] = await db.query('SELECT id FROM resources WHERE id = ?', [resourceId]);
+    if (rows.length === 0) {
+      return res.status(404).json({ error: 'Resource not found.' });
+    }
+
+    await db.query(
+      `UPDATE resources
+       SET title = COALESCE(?, title),
+           description = COALESCE(?, description),
+           url = COALESCE(?, url),
+           category = COALESCE(?, category),
+           min_mood = COALESCE(?, min_mood),
+           max_mood = COALESCE(?, max_mood)
+       WHERE id = ?`,
+      [
+        title ?? null,
+        description ?? null,
+        url ?? null,
+        category ?? null,
+        min_mood ?? null,
+        max_mood ?? null,
+        resourceId,
+      ]
+    );
+
+    res.json({ message: 'Resource updated.' });
+  } catch (err) {
+    console.error('Admin update resource error:', err);
+    res.status(500).json({ error: 'Failed to update resource.' });
+  }
+}
+
+// DELETE /api/admin/resources/:id
+async function deleteResource(req, res) {
+  const resourceId = parseInt(req.params.id, 10);
+
+  try {
+    const [rows] = await db.query('SELECT id FROM resources WHERE id = ?', [resourceId]);
+    if (rows.length === 0) {
+      return res.status(404).json({ error: 'Resource not found.' });
+    }
+
+    await db.query('DELETE FROM resources WHERE id = ?', [resourceId]);
+    res.json({ message: 'Resource deleted.' });
+  } catch (err) {
+    console.error('Admin delete resource error:', err);
+    res.status(500).json({ error: 'Failed to delete resource.' });
+  }
+}
+
+// GET /api/admin/bookings
+async function listBookings(req, res) {
+  try {
+    const [bookings] = await db.query(
+      `SELECT b.id, b.status, b.created_at,
+              u.email AS user_email,
+              t.slot_date, t.slot_time, t.time_of_day
+       FROM bookings b
+       JOIN users u ON b.user_id = u.id
+       JOIN therapy_slots t ON b.slot_id = t.id
+       ORDER BY b.created_at DESC`
+    );
+    res.json({ bookings });
+  } catch (err) {
+    console.error('Admin list bookings error:', err);
+    res.status(500).json({ error: 'Failed to fetch bookings.' });
+  }
+}
+
+// PATCH /api/admin/bookings/:id
+async function updateBooking(req, res) {
+  const bookingId = parseInt(req.params.id, 10);
+  const { status } = req.body;
+
+  if (!status || !['confirmed', 'declined'].includes(status)) {
+    return res.status(400).json({ error: 'status must be "confirmed" or "declined".' });
+  }
+
+  try {
+    const [rows] = await db.query(
+      'SELECT b.id, b.status, b.slot_id FROM bookings b WHERE b.id = ?',
+      [bookingId]
+    );
+
+    if (rows.length === 0) {
+      return res.status(404).json({ error: 'Booking not found.' });
+    }
+
+    const booking = rows[0];
+
+    if (booking.status === 'confirmed' || booking.status === 'declined') {
+      return res.status(409).json({ error: `Booking is already ${booking.status}.` });
+    }
+
+    await db.query('UPDATE bookings SET status = ? WHERE id = ?', [status, bookingId]);
+
+    // If declined, restore the slot to available
+    if (status === 'declined') {
+      await db.query('UPDATE therapy_slots SET status = "available" WHERE id = ?', [
+        booking.slot_id,
+      ]);
+    }
+
+    // If confirmed, mark the slot as booked
+    if (status === 'confirmed') {
+      await db.query('UPDATE therapy_slots SET status = "booked" WHERE id = ?', [booking.slot_id]);
+    }
+
+    res.json({ message: `Booking ${status}.` });
+  } catch (err) {
+    console.error('Admin update booking error:', err);
+    res.status(500).json({ error: 'Failed to update booking.' });
+  }
+}
+
+module.exports = {
+  listUsers,
+  listResources,
+  createResource,
+  updateResource,
+  deleteResource,
+  listBookings,
+  updateBooking,
+};

--- a/Server/src/routes/admin.js
+++ b/Server/src/routes/admin.js
@@ -2,57 +2,210 @@ const express = require('express');
 const router = express.Router();
 const authenticateToken = require('../middleware/auth');
 const requireAdmin = require('../middleware/requireAdmin');
-const db = require('../db/connection');
+const {
+  listUsers,
+  listResources,
+  createResource,
+  updateResource,
+  deleteResource,
+  listBookings,
+  updateBooking,
+} = require('../controllers/adminController');
+
+router.use(authenticateToken, requireAdmin);
 
 /**
  * @swagger
  * /api/admin/users:
  *   get:
  *     summary: List all registered users
- *     description: Returns every user account. Requires admin role.
  *     tags: [Admin]
  *     security:
  *       - bearerAuth: []
  *     responses:
  *       200:
  *         description: Array of all user accounts
- *         content:
- *           application/json:
- *             schema:
- *               type: object
- *               properties:
- *                 users:
- *                   type: array
- *                   items:
- *                     type: object
- *                     properties:
- *                       id:
- *                         type: integer
- *                         example: 1
- *                       email:
- *                         type: string
- *                         example: student@cardiffmet.ac.uk
- *                       role:
- *                         type: string
- *                         enum: [user, admin]
- *                       created_at:
- *                         type: string
- *                         format: date-time
  *       401:
  *         description: No token provided
  *       403:
  *         description: Admin role required
  */
-router.get('/users', authenticateToken, requireAdmin, async (req, res) => {
-  try {
-    const [users] = await db.query(
-      'SELECT id, email, role, created_at FROM users ORDER BY created_at DESC'
-    );
-    res.json({ users });
-  } catch (err) {
-    console.error('Admin users error:', err);
-    res.status(500).json({ error: 'Failed to fetch users.' });
-  }
-});
+router.get('/users', listUsers);
+
+/**
+ * @swagger
+ * /api/admin/resources:
+ *   get:
+ *     summary: List all resources
+ *     tags: [Admin]
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Array of all resources
+ *       403:
+ *         description: Admin role required
+ */
+router.get('/resources', listResources);
+
+/**
+ * @swagger
+ * /api/admin/resources:
+ *   post:
+ *     summary: Create a new resource
+ *     tags: [Admin]
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [title, url, category]
+ *             properties:
+ *               title:
+ *                 type: string
+ *               description:
+ *                 type: string
+ *               url:
+ *                 type: string
+ *               category:
+ *                 type: string
+ *                 enum: [crisis, anxiety, self-help, mindfulness, general]
+ *               min_mood:
+ *                 type: integer
+ *               max_mood:
+ *                 type: integer
+ *     responses:
+ *       201:
+ *         description: Resource created
+ *       400:
+ *         description: Missing required fields
+ *       403:
+ *         description: Admin role required
+ */
+router.post('/resources', createResource);
+
+/**
+ * @swagger
+ * /api/admin/resources/{id}:
+ *   patch:
+ *     summary: Update a resource
+ *     tags: [Admin]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: integer
+ *     requestBody:
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               title:
+ *                 type: string
+ *               description:
+ *                 type: string
+ *               url:
+ *                 type: string
+ *               category:
+ *                 type: string
+ *               min_mood:
+ *                 type: integer
+ *               max_mood:
+ *                 type: integer
+ *     responses:
+ *       200:
+ *         description: Resource updated
+ *       404:
+ *         description: Resource not found
+ *       403:
+ *         description: Admin role required
+ */
+router.patch('/resources/:id', updateResource);
+
+/**
+ * @swagger
+ * /api/admin/resources/{id}:
+ *   delete:
+ *     summary: Delete a resource
+ *     tags: [Admin]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: integer
+ *     responses:
+ *       200:
+ *         description: Resource deleted
+ *       404:
+ *         description: Resource not found
+ *       403:
+ *         description: Admin role required
+ */
+router.delete('/resources/:id', deleteResource);
+
+/**
+ * @swagger
+ * /api/admin/bookings:
+ *   get:
+ *     summary: List all bookings with user and slot details
+ *     tags: [Admin]
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Array of all bookings
+ *       403:
+ *         description: Admin role required
+ */
+router.get('/bookings', listBookings);
+
+/**
+ * @swagger
+ * /api/admin/bookings/{id}:
+ *   patch:
+ *     summary: Confirm or decline a booking
+ *     tags: [Admin]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: integer
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [status]
+ *             properties:
+ *               status:
+ *                 type: string
+ *                 enum: [confirmed, declined]
+ *     responses:
+ *       200:
+ *         description: Booking status updated
+ *       400:
+ *         description: Invalid status value
+ *       404:
+ *         description: Booking not found
+ *       409:
+ *         description: Booking already confirmed or declined
+ *       403:
+ *         description: Admin role required
+ */
+router.patch('/bookings/:id', updateBooking);
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- Dedicated adminController with 7 functions
- GET/POST/PATCH/DELETE /api/admin/resources — full resource management
- GET /api/admin/bookings — all bookings with user email + slot details
- PATCH /api/admin/bookings/:id — confirm/decline (restores slot on decline, marks booked on confirm)
- GET /api/admin/users — now includes deleted_at column
- Full Swagger annotations on all endpoints under Admin tag
- All endpoints protected by authenticateToken + requireAdmin (403 for regular users)

## Test plan
- [ ] CI lint + format passes
- [ ] All 123 tests pass
- [ ] 403 returned for non-admin on every endpoint
- [ ] Booking confirm marks slot as booked; decline restores to available