### PR TITLE
feat: Day 12 — admin dashboard

### DIFF
--- a/Client/src/App.jsx
+++ b/Client/src/App.jsx
@@ -13,6 +13,7 @@ import { useAuth } from '@/context';
 // Lazy-load heavy pages to keep the initial bundle small
 const MoodHistoryPage = lazy(() => import('@/pages/MoodHistoryPage'));
 const TherapistPage = lazy(() => import('@/pages/TherapistPage'));
+const AdminPage = lazy(() => import('@/pages/AdminPage'));
 
 function ProtectedRoute({
   children,
@@ -93,14 +94,11 @@ export default function App() {
           }
         />
 
-        {/* Day 12 — admin dashboard */}
         <Route
           path="/admin"
           element={
             <ProtectedRoute adminOnly>
-              <div className="text-slate-500 py-10 text-center">
-                Admin dashboard coming soon.
-              </div>
+              <AdminPage />
             </ProtectedRoute>
           }
         />

--- a/Client/src/pages/AdminPage/index.jsx
+++ b/Client/src/pages/AdminPage/index.jsx
@@ -6,7 +6,34 @@ import ErrorBanner from '@/components/ErrorBanner';
 import LoadingSpinner from '@/components/LoadingSpinner';
 import EmptyState from '@/components/EmptyState';
 
-const CATEGORIES = ['general', 'crisis', 'anxiety', 'self-help', 'mindfulness'];
+const CATEGORIES = [
+  {
+    key: 'general',
+    label: 'General',
+    style: 'bg-slate-100 text-slate-600 border-slate-200',
+  },
+  {
+    key: 'crisis',
+    label: 'Crisis',
+    style: 'bg-red-100 text-red-700 border-red-200',
+  },
+  {
+    key: 'anxiety',
+    label: 'Anxiety',
+    style: 'bg-amber-100 text-amber-700 border-amber-200',
+  },
+  {
+    key: 'self-help',
+    label: 'Self-help',
+    style: 'bg-blue-100 text-blue-700 border-blue-200',
+  },
+  {
+    key: 'mindfulness',
+    label: 'Mindfulness',
+    style: 'bg-teal-100 text-teal-700 border-teal-200',
+  },
+];
+const CAT_STYLE = Object.fromEntries(CATEGORIES.map((c) => [c.key, c.style]));
 const ROLES = ['user', 'therapist', 'admin'];
 
 const ROLE_STYLES = {
@@ -339,10 +366,22 @@ const EMPTY_FORM = {
   title: '',
   description: '',
   url: '',
-  category: 'general',
+  categories: ['general'],
   min_mood: 1,
   max_mood: 5,
 };
+
+function parseCategories(raw) {
+  if (Array.isArray(raw)) return raw;
+  if (typeof raw === 'string') {
+    try {
+      return JSON.parse(raw);
+    } catch {
+      return [raw];
+    }
+  }
+  return [];
+}
 
 function ResourcesTab({ authFetch }) {
   const [resources, setResources] = useState([]);
@@ -386,12 +425,28 @@ function ResourcesTab({ authFetch }) {
       title: r.title,
       description: r.description ?? '',
       url: r.url,
-      category: r.category,
+      categories:
+        parseCategories(r.categories).length > 0
+          ? parseCategories(r.categories)
+          : [r.category || 'general'],
       min_mood: r.min_mood,
       max_mood: r.max_mood,
     });
     setShowForm(true);
     setError('');
+  }
+
+  function toggleCategory(key) {
+    setForm((f) => {
+      const has = f.categories.includes(key);
+      if (has && f.categories.length === 1) return f; // must keep at least one
+      return {
+        ...f,
+        categories: has
+          ? f.categories.filter((c) => c !== key)
+          : [...f.categories, key],
+      };
+    });
   }
 
   async function handleSave(e) {
@@ -407,6 +462,7 @@ function ResourcesTab({ authFetch }) {
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
             ...form,
+            categories: form.categories,
             min_mood: Number(form.min_mood),
             max_mood: Number(form.max_mood),
           }),
@@ -524,23 +580,32 @@ function ResourcesTab({ authFetch }) {
                   className="w-full px-3 py-2 rounded-lg border border-slate-300 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
                 />
               </div>
-              <div>
-                <label className="block text-sm font-medium text-slate-700 mb-1">
-                  Category *
+              <div className="col-span-2">
+                <label className="block text-sm font-medium text-slate-700 mb-2">
+                  Categories *{' '}
+                  <span className="text-slate-400 font-normal">
+                    (select all that apply)
+                  </span>
                 </label>
-                <select
-                  value={form.category}
-                  onChange={(e) =>
-                    setForm((f) => ({ ...f, category: e.target.value }))
-                  }
-                  className="w-full px-3 py-2 rounded-lg border border-slate-300 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 bg-white"
-                >
-                  {CATEGORIES.map((c) => (
-                    <option key={c} value={c}>
-                      {c}
-                    </option>
-                  ))}
-                </select>
+                <div className="flex flex-wrap gap-2">
+                  {CATEGORIES.map(({ key, label, style }) => {
+                    const selected = form.categories.includes(key);
+                    return (
+                      <button
+                        key={key}
+                        type="button"
+                        onClick={() => toggleCategory(key)}
+                        className={`px-3 py-1 rounded-full text-xs font-semibold border transition-colors ${
+                          selected
+                            ? style + ' ring-2 ring-offset-1 ring-indigo-400'
+                            : 'bg-white border-slate-200 text-slate-500 hover:border-slate-300'
+                        }`}
+                      >
+                        {label}
+                      </button>
+                    );
+                  })}
+                </div>
               </div>
               <div className="flex gap-3">
                 <div className="flex-1">
@@ -637,9 +702,16 @@ function ResourcesTab({ authFetch }) {
                     )}
                   </td>
                   <td className="px-4 py-3">
-                    <span className="text-xs font-medium px-2 py-0.5 bg-indigo-50 text-indigo-600 rounded-full capitalize">
-                      {r.category}
-                    </span>
+                    <div className="flex flex-wrap gap-1">
+                      {parseCategories(r.categories).map((cat) => (
+                        <span
+                          key={cat}
+                          className={`text-xs font-medium px-2 py-0.5 rounded-full border capitalize ${CAT_STYLE[cat] ?? 'bg-slate-100 text-slate-600 border-slate-200'}`}
+                        >
+                          {cat}
+                        </span>
+                      ))}
+                    </div>
                   </td>
                   <td className="px-4 py-3 text-slate-500">
                     {r.min_mood}–{r.max_mood}

--- a/Client/src/pages/AdminPage/index.jsx
+++ b/Client/src/pages/AdminPage/index.jsx
@@ -1,0 +1,720 @@
+import { useState, useEffect } from 'react';
+import { useAuth } from '@/context';
+import Card from '@/components/Card';
+import Button from '@/components/Button';
+import ErrorBanner from '@/components/ErrorBanner';
+import LoadingSpinner from '@/components/LoadingSpinner';
+import EmptyState from '@/components/EmptyState';
+
+const CATEGORIES = ['general', 'crisis', 'anxiety', 'self-help', 'mindfulness'];
+const ROLES = ['user', 'therapist', 'admin'];
+
+const ROLE_STYLES = {
+  user: 'bg-slate-100 text-slate-600',
+  therapist: 'bg-teal-100 text-teal-700',
+  admin: 'bg-violet-100 text-violet-700',
+};
+
+const STATUS_STYLES = {
+  pending: 'bg-amber-50 text-amber-700 border-amber-200',
+  confirmed: 'bg-green-50 text-green-700 border-green-200',
+  declined: 'bg-red-50 text-red-700 border-red-200',
+};
+
+function formatDate(raw) {
+  if (!raw) return '—';
+  const d = new Date(String(raw).replace(' ', 'T'));
+  return isNaN(d)
+    ? '—'
+    : d.toLocaleDateString('en-GB', {
+        day: 'numeric',
+        month: 'short',
+        year: 'numeric',
+      });
+}
+
+function displayTime(hhmm) {
+  if (!hhmm) return '';
+  const [h, m] = String(hhmm).slice(0, 5).split(':').map(Number);
+  const ampm = h >= 12 ? 'pm' : 'am';
+  return `${h > 12 ? h - 12 : h}:${String(m).padStart(2, '0')} ${ampm}`;
+}
+
+// ─── Users Tab ────────────────────────────────────────────────────────────────
+
+function UsersTab({ authFetch, currentUserId }) {
+  const [users, setUsers] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+  const [changingId, setChangingId] = useState(null);
+
+  useEffect(() => {
+    async function fetchUsers() {
+      try {
+        const res = await authFetch('/api/admin/users');
+        const data = await res.json();
+        if (!res.ok) {
+          setError(data.error);
+          return;
+        }
+        setUsers(data.users ?? []);
+      } catch {
+        setError('Could not load users.');
+      } finally {
+        setLoading(false);
+      }
+    }
+    fetchUsers();
+  }, [authFetch]);
+
+  async function handleRoleChange(userId, newRole) {
+    setChangingId(userId);
+    setError('');
+    try {
+      const res = await authFetch(`/api/admin/users/${userId}/role`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ role: newRole }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        setError(data.error);
+        return;
+      }
+      setUsers((prev) =>
+        prev.map((u) => (u.id === userId ? { ...u, role: newRole } : u))
+      );
+    } catch {
+      setError('Could not update role.');
+    } finally {
+      setChangingId(null);
+    }
+  }
+
+  if (loading) return <LoadingSpinner message="Loading users…" />;
+
+  return (
+    <>
+      <ErrorBanner message={error} className="mb-4" />
+      <div className="overflow-x-auto rounded-xl border border-slate-200 shadow-sm">
+        <table className="w-full text-sm">
+          <thead className="bg-slate-50 border-b border-slate-200">
+            <tr>
+              <th className="text-left px-4 py-3 font-medium text-slate-500">
+                Email
+              </th>
+              <th className="text-left px-4 py-3 font-medium text-slate-500">
+                Name
+              </th>
+              <th className="text-left px-4 py-3 font-medium text-slate-500">
+                Role
+              </th>
+              <th className="text-left px-4 py-3 font-medium text-slate-500">
+                Joined
+              </th>
+              <th className="text-left px-4 py-3 font-medium text-slate-500">
+                Status
+              </th>
+              <th className="px-4 py-3" />
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-slate-100 bg-white">
+            {users.map((u) => (
+              <tr key={u.id} className={u.deleted_at ? 'opacity-40' : ''}>
+                <td className="px-4 py-3 text-slate-800 font-medium">
+                  {u.email}
+                </td>
+                <td className="px-4 py-3 text-slate-500">{u.name || '—'}</td>
+                <td className="px-4 py-3">
+                  <span
+                    className={`text-xs font-semibold px-2 py-0.5 rounded-full ${ROLE_STYLES[u.role]}`}
+                  >
+                    {u.role}
+                  </span>
+                </td>
+                <td className="px-4 py-3 text-slate-500">
+                  {formatDate(u.created_at)}
+                </td>
+                <td className="px-4 py-3">
+                  {u.deleted_at ? (
+                    <span className="text-xs text-red-400 font-medium">
+                      Deleted
+                    </span>
+                  ) : (
+                    <span className="text-xs text-green-600 font-medium">
+                      Active
+                    </span>
+                  )}
+                </td>
+                <td className="px-4 py-3">
+                  {!u.deleted_at && u.id !== currentUserId && (
+                    <select
+                      value={u.role}
+                      disabled={changingId === u.id}
+                      onChange={(e) => handleRoleChange(u.id, e.target.value)}
+                      className="text-xs border border-slate-200 rounded-lg px-2 py-1 bg-white text-slate-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 disabled:opacity-50"
+                    >
+                      {ROLES.map((r) => (
+                        <option key={r} value={r}>
+                          {r}
+                        </option>
+                      ))}
+                    </select>
+                  )}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+        {users.length === 0 && (
+          <EmptyState
+            icon="👤"
+            title="No users found"
+            message="No accounts have been registered yet."
+          />
+        )}
+      </div>
+      <p className="text-xs text-slate-400 mt-2">
+        {users.length} account{users.length !== 1 ? 's' : ''} total
+      </p>
+    </>
+  );
+}
+
+// ─── Bookings Tab ─────────────────────────────────────────────────────────────
+
+function BookingsTab({ authFetch }) {
+  const [bookings, setBookings] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+  const [updatingId, setUpdatingId] = useState(null);
+
+  useEffect(() => {
+    async function fetchBookings() {
+      try {
+        const res = await authFetch('/api/admin/bookings');
+        const data = await res.json();
+        if (!res.ok) {
+          setError(data.error);
+          return;
+        }
+        setBookings(data.bookings ?? []);
+      } catch {
+        setError('Could not load bookings.');
+      } finally {
+        setLoading(false);
+      }
+    }
+    fetchBookings();
+  }, [authFetch]);
+
+  async function handleStatus(bookingId, status) {
+    setUpdatingId(bookingId);
+    setError('');
+    try {
+      const res = await authFetch(`/api/admin/bookings/${bookingId}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ status }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        setError(data.error);
+        return;
+      }
+      setBookings((prev) =>
+        prev.map((b) => (b.id === bookingId ? { ...b, status } : b))
+      );
+    } catch {
+      setError('Could not update booking.');
+    } finally {
+      setUpdatingId(null);
+    }
+  }
+
+  if (loading) return <LoadingSpinner message="Loading bookings…" />;
+
+  const pending = bookings.filter((b) => b.status === 'pending');
+  const rest = bookings.filter((b) => b.status !== 'pending');
+
+  return (
+    <>
+      <ErrorBanner message={error} className="mb-4" />
+      {bookings.length === 0 ? (
+        <EmptyState
+          icon="📅"
+          title="No bookings yet"
+          message="No therapy sessions have been requested yet."
+        />
+      ) : (
+        <div className="space-y-6">
+          {pending.length > 0 && (
+            <div>
+              <h3 className="text-sm font-semibold text-slate-600 mb-2">
+                Pending ({pending.length})
+              </h3>
+              <div className="space-y-2">
+                {pending.map((b) => (
+                  <BookingRow
+                    key={b.id}
+                    booking={b}
+                    updatingId={updatingId}
+                    onStatus={handleStatus}
+                  />
+                ))}
+              </div>
+            </div>
+          )}
+          {rest.length > 0 && (
+            <div>
+              <h3 className="text-sm font-semibold text-slate-600 mb-2">
+                Past decisions
+              </h3>
+              <div className="space-y-2">
+                {rest.map((b) => (
+                  <BookingRow
+                    key={b.id}
+                    booking={b}
+                    updatingId={updatingId}
+                    onStatus={handleStatus}
+                  />
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </>
+  );
+}
+
+function BookingRow({ booking: b, updatingId, onStatus }) {
+  const timeKey = String(b.slot_time).slice(0, 5);
+  const [h] = timeKey.split(':').map(Number);
+  const endTime = `${String(h + 1).padStart(2, '0')}:00`;
+  const busy = updatingId === b.id;
+
+  return (
+    <Card className="flex items-center justify-between gap-4">
+      <div className="min-w-0">
+        <p className="font-medium text-slate-800 truncate">{b.user_email}</p>
+        <p className="text-sm text-slate-500 mt-0.5">
+          {formatDate(b.slot_date)} · {displayTime(timeKey)} –{' '}
+          {displayTime(endTime)}
+        </p>
+      </div>
+      <div className="flex items-center gap-3 shrink-0">
+        <span
+          className={`text-xs font-semibold px-2.5 py-1 rounded-full border capitalize ${STATUS_STYLES[b.status] ?? 'bg-slate-50 text-slate-600 border-slate-200'}`}
+        >
+          {b.status}
+        </span>
+        {b.status === 'pending' && (
+          <>
+            <Button
+              size="sm"
+              disabled={busy}
+              onClick={() => onStatus(b.id, 'confirmed')}
+            >
+              {busy ? '…' : 'Confirm'}
+            </Button>
+            <Button
+              size="sm"
+              variant="danger"
+              disabled={busy}
+              onClick={() => onStatus(b.id, 'declined')}
+            >
+              {busy ? '…' : 'Decline'}
+            </Button>
+          </>
+        )}
+      </div>
+    </Card>
+  );
+}
+
+// ─── Resources Tab ────────────────────────────────────────────────────────────
+
+const EMPTY_FORM = {
+  title: '',
+  description: '',
+  url: '',
+  category: 'general',
+  min_mood: 1,
+  max_mood: 5,
+};
+
+function ResourcesTab({ authFetch }) {
+  const [resources, setResources] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+  const [editingId, setEditingId] = useState(null); // null = new, number = editing
+  const [showForm, setShowForm] = useState(false);
+  const [form, setForm] = useState(EMPTY_FORM);
+  const [saving, setSaving] = useState(false);
+  const [deletingId, setDeletingId] = useState(null);
+
+  useEffect(() => {
+    async function fetchResources() {
+      try {
+        const res = await authFetch('/api/admin/resources');
+        const data = await res.json();
+        if (!res.ok) {
+          setError(data.error);
+          return;
+        }
+        setResources(data.resources ?? []);
+      } catch {
+        setError('Could not load resources.');
+      } finally {
+        setLoading(false);
+      }
+    }
+    fetchResources();
+  }, [authFetch]);
+
+  function openNew() {
+    setEditingId(null);
+    setForm(EMPTY_FORM);
+    setShowForm(true);
+    setError('');
+  }
+
+  function openEdit(r) {
+    setEditingId(r.id);
+    setForm({
+      title: r.title,
+      description: r.description ?? '',
+      url: r.url,
+      category: r.category,
+      min_mood: r.min_mood,
+      max_mood: r.max_mood,
+    });
+    setShowForm(true);
+    setError('');
+  }
+
+  async function handleSave(e) {
+    e.preventDefault();
+    setSaving(true);
+    setError('');
+    try {
+      const isNew = editingId === null;
+      const res = await authFetch(
+        isNew ? '/api/admin/resources' : `/api/admin/resources/${editingId}`,
+        {
+          method: isNew ? 'POST' : 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            ...form,
+            min_mood: Number(form.min_mood),
+            max_mood: Number(form.max_mood),
+          }),
+        }
+      );
+      const data = await res.json();
+      if (!res.ok) {
+        setError(data.error);
+        return;
+      }
+
+      if (isNew) {
+        setResources((prev) => [
+          ...prev,
+          {
+            id: data.resourceId,
+            ...form,
+            min_mood: Number(form.min_mood),
+            max_mood: Number(form.max_mood),
+          },
+        ]);
+      } else {
+        setResources((prev) =>
+          prev.map((r) =>
+            r.id === editingId
+              ? {
+                  ...r,
+                  ...form,
+                  min_mood: Number(form.min_mood),
+                  max_mood: Number(form.max_mood),
+                }
+              : r
+          )
+        );
+      }
+      setShowForm(false);
+    } catch {
+      setError('Could not save resource.');
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleDelete(id) {
+    setDeletingId(id);
+    setError('');
+    try {
+      const res = await authFetch(`/api/admin/resources/${id}`, {
+        method: 'DELETE',
+      });
+      if (!res.ok) {
+        const data = await res.json();
+        setError(data.error);
+        return;
+      }
+      setResources((prev) => prev.filter((r) => r.id !== id));
+    } catch {
+      setError('Could not delete resource.');
+    } finally {
+      setDeletingId(null);
+    }
+  }
+
+  if (loading) return <LoadingSpinner message="Loading resources…" />;
+
+  return (
+    <>
+      <ErrorBanner message={error} className="mb-4" />
+
+      {showForm && (
+        <Card className="mb-6 border-indigo-200">
+          <h3 className="text-base font-semibold text-slate-800 mb-4">
+            {editingId === null ? 'Add resource' : 'Edit resource'}
+          </h3>
+          <form onSubmit={handleSave} className="space-y-4">
+            <div className="grid grid-cols-2 gap-4">
+              <div className="col-span-2">
+                <label className="block text-sm font-medium text-slate-700 mb-1">
+                  Title *
+                </label>
+                <input
+                  type="text"
+                  required
+                  value={form.title}
+                  onChange={(e) =>
+                    setForm((f) => ({ ...f, title: e.target.value }))
+                  }
+                  className="w-full px-3 py-2 rounded-lg border border-slate-300 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                />
+              </div>
+              <div className="col-span-2">
+                <label className="block text-sm font-medium text-slate-700 mb-1">
+                  Description
+                </label>
+                <textarea
+                  rows={2}
+                  value={form.description}
+                  onChange={(e) =>
+                    setForm((f) => ({ ...f, description: e.target.value }))
+                  }
+                  className="w-full px-3 py-2 rounded-lg border border-slate-300 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 resize-none"
+                />
+              </div>
+              <div className="col-span-2">
+                <label className="block text-sm font-medium text-slate-700 mb-1">
+                  URL *
+                </label>
+                <input
+                  type="url"
+                  required
+                  value={form.url}
+                  onChange={(e) =>
+                    setForm((f) => ({ ...f, url: e.target.value }))
+                  }
+                  className="w-full px-3 py-2 rounded-lg border border-slate-300 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                />
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-slate-700 mb-1">
+                  Category *
+                </label>
+                <select
+                  value={form.category}
+                  onChange={(e) =>
+                    setForm((f) => ({ ...f, category: e.target.value }))
+                  }
+                  className="w-full px-3 py-2 rounded-lg border border-slate-300 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 bg-white"
+                >
+                  {CATEGORIES.map((c) => (
+                    <option key={c} value={c}>
+                      {c}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div className="flex gap-3">
+                <div className="flex-1">
+                  <label className="block text-sm font-medium text-slate-700 mb-1">
+                    Min mood
+                  </label>
+                  <input
+                    type="number"
+                    min={1}
+                    max={5}
+                    value={form.min_mood}
+                    onChange={(e) =>
+                      setForm((f) => ({ ...f, min_mood: e.target.value }))
+                    }
+                    className="w-full px-3 py-2 rounded-lg border border-slate-300 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                  />
+                </div>
+                <div className="flex-1">
+                  <label className="block text-sm font-medium text-slate-700 mb-1">
+                    Max mood
+                  </label>
+                  <input
+                    type="number"
+                    min={1}
+                    max={5}
+                    value={form.max_mood}
+                    onChange={(e) =>
+                      setForm((f) => ({ ...f, max_mood: e.target.value }))
+                    }
+                    className="w-full px-3 py-2 rounded-lg border border-slate-300 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                  />
+                </div>
+              </div>
+            </div>
+            <div className="flex gap-3 pt-1">
+              <Button type="submit" disabled={saving}>
+                {saving ? 'Saving…' : 'Save resource'}
+              </Button>
+              <Button
+                type="button"
+                variant="secondary"
+                onClick={() => setShowForm(false)}
+              >
+                Cancel
+              </Button>
+            </div>
+          </form>
+        </Card>
+      )}
+
+      <div className="flex justify-between items-center mb-3">
+        <p className="text-sm text-slate-500">
+          {resources.length} resource{resources.length !== 1 ? 's' : ''}
+        </p>
+        {!showForm && (
+          <Button size="sm" onClick={openNew}>
+            + Add resource
+          </Button>
+        )}
+      </div>
+
+      {resources.length === 0 ? (
+        <EmptyState
+          icon="📚"
+          title="No resources"
+          message="Add your first resource using the button above."
+        />
+      ) : (
+        <div className="overflow-x-auto rounded-xl border border-slate-200 shadow-sm">
+          <table className="w-full text-sm">
+            <thead className="bg-slate-50 border-b border-slate-200">
+              <tr>
+                <th className="text-left px-4 py-3 font-medium text-slate-500">
+                  Title
+                </th>
+                <th className="text-left px-4 py-3 font-medium text-slate-500">
+                  Category
+                </th>
+                <th className="text-left px-4 py-3 font-medium text-slate-500">
+                  Mood range
+                </th>
+                <th className="px-4 py-3" />
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-slate-100 bg-white">
+              {resources.map((r) => (
+                <tr key={r.id}>
+                  <td className="px-4 py-3">
+                    <p className="font-medium text-slate-800">{r.title}</p>
+                    {r.description && (
+                      <p className="text-xs text-slate-400 truncate max-w-xs">
+                        {r.description}
+                      </p>
+                    )}
+                  </td>
+                  <td className="px-4 py-3">
+                    <span className="text-xs font-medium px-2 py-0.5 bg-indigo-50 text-indigo-600 rounded-full capitalize">
+                      {r.category}
+                    </span>
+                  </td>
+                  <td className="px-4 py-3 text-slate-500">
+                    {r.min_mood}–{r.max_mood}
+                  </td>
+                  <td className="px-4 py-3">
+                    <div className="flex gap-2 justify-end">
+                      <Button
+                        size="sm"
+                        variant="secondary"
+                        onClick={() => openEdit(r)}
+                      >
+                        Edit
+                      </Button>
+                      <Button
+                        size="sm"
+                        variant="danger"
+                        disabled={deletingId === r.id}
+                        onClick={() => handleDelete(r.id)}
+                      >
+                        {deletingId === r.id ? '…' : 'Delete'}
+                      </Button>
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </>
+  );
+}
+
+// ─── Page ─────────────────────────────────────────────────────────────────────
+
+const TABS = [
+  { key: 'users', label: 'Users' },
+  { key: 'bookings', label: 'Bookings' },
+  { key: 'resources', label: 'Resources' },
+];
+
+export default function AdminPage() {
+  const { authFetch, user } = useAuth();
+  const [tab, setTab] = useState('users');
+
+  return (
+    <div className="max-w-5xl mx-auto">
+      <div className="mb-8">
+        <h1 className="text-3xl font-bold text-slate-900">Admin Dashboard</h1>
+        <p className="text-slate-500 mt-1">
+          Manage users, bookings, and resources.
+        </p>
+      </div>
+
+      <div className="flex gap-1 mb-6 border-b border-slate-200">
+        {TABS.map(({ key, label }) => (
+          <button
+            key={key}
+            onClick={() => setTab(key)}
+            className={`px-5 py-2.5 text-sm font-medium transition-colors border-b-2 -mb-px ${
+              tab === key
+                ? 'border-violet-600 text-violet-600'
+                : 'border-transparent text-slate-500 hover:text-slate-700'
+            }`}
+          >
+            {label}
+          </button>
+        ))}
+      </div>
+
+      {tab === 'users' && (
+        <UsersTab authFetch={authFetch} currentUserId={user?.userId} />
+      )}
+      {tab === 'bookings' && <BookingsTab authFetch={authFetch} />}
+      {tab === 'resources' && <ResourcesTab authFetch={authFetch} />}
+    </div>
+  );
+}

--- a/Client/src/pages/ResourcesPage/index.jsx
+++ b/Client/src/pages/ResourcesPage/index.jsx
@@ -7,12 +7,68 @@ import EmptyState from '@/components/EmptyState';
 
 const CATEGORIES = [
   { key: 'all', label: 'All' },
-  { key: 'crisis', label: 'Crisis', icon: '🆘' },
-  { key: 'anxiety', label: 'Anxiety', icon: '😰' },
-  { key: 'self-help', label: 'Self-help', icon: '📖' },
-  { key: 'mindfulness', label: 'Mindfulness', icon: '🧘' },
-  { key: 'general', label: 'General', icon: '💚' },
+  {
+    key: 'crisis',
+    label: 'Crisis',
+    icon: '🆘',
+    chip: 'bg-red-100 text-red-700 border-red-200',
+    active: 'bg-red-600 text-white',
+  },
+  {
+    key: 'anxiety',
+    label: 'Anxiety',
+    icon: '😰',
+    chip: 'bg-amber-100 text-amber-700 border-amber-200',
+    active: 'bg-amber-500 text-white',
+  },
+  {
+    key: 'self-help',
+    label: 'Self-help',
+    icon: '📖',
+    chip: 'bg-blue-100 text-blue-700 border-blue-200',
+    active: 'bg-blue-600 text-white',
+  },
+  {
+    key: 'mindfulness',
+    label: 'Mindfulness',
+    icon: '🧘',
+    chip: 'bg-teal-100 text-teal-700 border-teal-200',
+    active: 'bg-teal-600 text-white',
+  },
+  {
+    key: 'general',
+    label: 'General',
+    icon: '💚',
+    chip: 'bg-slate-100 text-slate-600 border-slate-200',
+    active: 'bg-slate-600 text-white',
+  },
 ];
+
+const CAT_MAP = Object.fromEntries(CATEGORIES.slice(1).map((c) => [c.key, c]));
+
+function parseCategories(raw) {
+  if (Array.isArray(raw)) return raw;
+  if (typeof raw === 'string') {
+    try {
+      return JSON.parse(raw);
+    } catch {
+      return [raw];
+    }
+  }
+  return [];
+}
+
+function CategoryTag({ cat }) {
+  const meta = CAT_MAP[cat];
+  if (!meta) return null;
+  return (
+    <span
+      className={`shrink-0 text-xs font-medium px-2 py-0.5 rounded-full border capitalize ${meta.chip}`}
+    >
+      {meta.icon} {meta.label}
+    </span>
+  );
+}
 
 export default function ResourcesPage() {
   const { authFetch } = useAuth();
@@ -70,7 +126,7 @@ export default function ResourcesPage() {
         });
       }
     } catch {
-      // silently ignore save toggle errors
+      // silently ignore
     } finally {
       setSavingId(null);
     }
@@ -78,7 +134,10 @@ export default function ResourcesPage() {
 
   const displayed = resources.filter((r) => {
     if (showSaved && !savedIds.has(r.id)) return false;
-    if (category !== 'all' && r.category !== category) return false;
+    if (category !== 'all') {
+      const cats = parseCategories(r.categories);
+      if (!cats.includes(category)) return false;
+    }
     return true;
   });
 
@@ -99,20 +158,33 @@ export default function ResourcesPage() {
 
       {/* Filter bar */}
       <div className="flex flex-wrap items-center gap-2 mb-6">
-        {CATEGORIES.map(({ key, label, icon }) => (
+        <button
+          onClick={() => {
+            setCategory('all');
+            setShowSaved(false);
+          }}
+          className={`px-3.5 py-1.5 rounded-full text-sm font-medium border transition-colors ${
+            category === 'all' && !showSaved
+              ? 'bg-indigo-600 text-white border-indigo-600 shadow-sm'
+              : 'bg-white border-slate-200 text-slate-600 hover:border-slate-300'
+          }`}
+        >
+          All
+        </button>
+        {CATEGORIES.slice(1).map(({ key, label, icon, active }) => (
           <button
             key={key}
             onClick={() => {
               setCategory(key);
               setShowSaved(false);
             }}
-            className={`px-3.5 py-1.5 rounded-full text-sm font-medium transition-colors ${
+            className={`px-3.5 py-1.5 rounded-full text-sm font-medium border transition-colors ${
               category === key && !showSaved
-                ? 'bg-indigo-600 text-white shadow-sm'
-                : 'bg-white border border-slate-200 text-slate-600 hover:border-slate-300'
+                ? `${active} border-transparent shadow-sm`
+                : 'bg-white border-slate-200 text-slate-600 hover:border-slate-300'
             }`}
           >
-            {icon && <span className="mr-1">{icon}</span>}
+            <span className="mr-1">{icon}</span>
             {label}
           </button>
         ))}
@@ -121,10 +193,10 @@ export default function ResourcesPage() {
             setShowSaved(true);
             setCategory('all');
           }}
-          className={`ml-auto px-3.5 py-1.5 rounded-full text-sm font-medium transition-colors ${
+          className={`ml-auto px-3.5 py-1.5 rounded-full text-sm font-medium border transition-colors ${
             showSaved
-              ? 'bg-green-600 text-white shadow-sm'
-              : 'bg-white border border-slate-200 text-slate-600 hover:border-slate-300'
+              ? 'bg-green-600 text-white border-green-600 shadow-sm'
+              : 'bg-white border-slate-200 text-slate-600 hover:border-slate-300'
           }`}
         >
           🔖 Saved ({savedIds.size})
@@ -144,44 +216,49 @@ export default function ResourcesPage() {
         />
       ) : (
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-          {displayed.map((resource) => (
-            <Card key={resource.id} className="flex flex-col">
-              <div className="flex items-start justify-between gap-2 mb-2">
-                <h3 className="font-semibold text-slate-800 text-base">
-                  {resource.title}
-                </h3>
-                {resource.category && (
-                  <span className="shrink-0 text-xs font-medium px-2 py-0.5 rounded-full bg-slate-100 text-slate-500 capitalize">
-                    {resource.category}
-                  </span>
+          {displayed.map((resource) => {
+            const cats = parseCategories(resource.categories);
+            return (
+              <Card key={resource.id} className="flex flex-col">
+                <div className="flex items-start justify-between gap-2 mb-2">
+                  <h3 className="font-semibold text-slate-800 text-base">
+                    {resource.title}
+                  </h3>
+                </div>
+                {cats.length > 0 && (
+                  <div className="flex flex-wrap gap-1.5 mb-2">
+                    {cats.map((cat) => (
+                      <CategoryTag key={cat} cat={cat} />
+                    ))}
+                  </div>
                 )}
-              </div>
-              <p className="text-sm text-slate-500 flex-1 mb-4">
-                {resource.description}
-              </p>
-              <div className="flex items-center gap-3">
-                <a
-                  href={resource.url}
-                  target="_blank"
-                  rel="noreferrer"
-                  className="flex-1 text-center py-2 bg-indigo-600 hover:bg-indigo-700 text-white text-sm font-semibold rounded-lg transition-colors"
-                >
-                  Visit resource
-                </a>
-                <button
-                  onClick={() => toggleSave(resource.id)}
-                  disabled={savingId === resource.id}
-                  className={`px-4 py-2 rounded-lg text-sm font-medium border transition-colors disabled:opacity-60 ${
-                    savedIds.has(resource.id)
-                      ? 'border-green-300 bg-green-50 text-green-700 hover:bg-red-50 hover:border-red-300 hover:text-red-600'
-                      : 'border-slate-300 bg-white text-slate-600 hover:border-slate-400'
-                  }`}
-                >
-                  {savedIds.has(resource.id) ? '✓ Saved' : 'Save'}
-                </button>
-              </div>
-            </Card>
-          ))}
+                <p className="text-sm text-slate-500 flex-1 mb-4">
+                  {resource.description}
+                </p>
+                <div className="flex items-center gap-3">
+                  <a
+                    href={resource.url}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="flex-1 text-center py-2 bg-indigo-600 hover:bg-indigo-700 text-white text-sm font-semibold rounded-lg transition-colors"
+                  >
+                    Visit resource
+                  </a>
+                  <button
+                    onClick={() => toggleSave(resource.id)}
+                    disabled={savingId === resource.id}
+                    className={`px-4 py-2 rounded-lg text-sm font-medium border transition-colors disabled:opacity-60 ${
+                      savedIds.has(resource.id)
+                        ? 'border-green-300 bg-green-50 text-green-700 hover:bg-red-50 hover:border-red-300 hover:text-red-600'
+                        : 'border-slate-300 bg-white text-slate-600 hover:border-slate-400'
+                    }`}
+                  >
+                    {savedIds.has(resource.id) ? '✓ Saved' : 'Save'}
+                  </button>
+                </div>
+              </Card>
+            );
+          })}
         </div>
       )}
     </div>

--- a/Server/src/controllers/adminController.js
+++ b/Server/src/controllers/adminController.js
@@ -24,18 +24,26 @@ async function listResources(req, res) {
   }
 }
 
+const VALID_CATEGORIES = ['general', 'crisis', 'anxiety', 'self-help', 'mindfulness'];
+
 // POST /api/admin/resources
 async function createResource(req, res) {
-  const { title, description, url, category, min_mood, max_mood } = req.body;
+  const { title, description, url, categories, min_mood, max_mood } = req.body;
 
-  if (!title || !url || !category) {
-    return res.status(400).json({ error: 'title, url, and category are required.' });
+  if (!title || !url) {
+    return res.status(400).json({ error: 'title and url are required.' });
+  }
+
+  const cats = Array.isArray(categories) && categories.length > 0 ? categories : ['general'];
+  const invalid = cats.filter((c) => !VALID_CATEGORIES.includes(c));
+  if (invalid.length > 0) {
+    return res.status(400).json({ error: `Invalid categories: ${invalid.join(', ')}.` });
   }
 
   try {
     const [result] = await db.query(
-      'INSERT INTO resources (title, description, url, category, min_mood, max_mood) VALUES (?, ?, ?, ?, ?, ?)',
-      [title, description || null, url, category, min_mood ?? 1, max_mood ?? 5]
+      'INSERT INTO resources (title, description, url, category, categories, min_mood, max_mood) VALUES (?, ?, ?, ?, ?, ?, ?)',
+      [title, description || null, url, cats[0], JSON.stringify(cats), min_mood ?? 1, max_mood ?? 5]
     );
     res.status(201).json({ message: 'Resource created.', resourceId: result.insertId });
   } catch (err) {
@@ -47,7 +55,7 @@ async function createResource(req, res) {
 // PATCH /api/admin/resources/:id
 async function updateResource(req, res) {
   const resourceId = parseInt(req.params.id, 10);
-  const { title, description, url, category, min_mood, max_mood } = req.body;
+  const { title, description, url, categories, min_mood, max_mood } = req.body;
 
   try {
     const [rows] = await db.query('SELECT id FROM resources WHERE id = ?', [resourceId]);
@@ -55,12 +63,15 @@ async function updateResource(req, res) {
       return res.status(404).json({ error: 'Resource not found.' });
     }
 
+    const cats = Array.isArray(categories) && categories.length > 0 ? categories : null;
+
     await db.query(
       `UPDATE resources
        SET title = COALESCE(?, title),
            description = COALESCE(?, description),
            url = COALESCE(?, url),
            category = COALESCE(?, category),
+           categories = COALESCE(?, categories),
            min_mood = COALESCE(?, min_mood),
            max_mood = COALESCE(?, max_mood)
        WHERE id = ?`,
@@ -68,7 +79,8 @@ async function updateResource(req, res) {
         title ?? null,
         description ?? null,
         url ?? null,
-        category ?? null,
+        cats ? cats[0] : null,
+        cats ? JSON.stringify(cats) : null,
         min_mood ?? null,
         max_mood ?? null,
         resourceId,

--- a/Server/src/controllers/adminController.js
+++ b/Server/src/controllers/adminController.js
@@ -4,7 +4,7 @@ const db = require('../db/connection');
 async function listUsers(req, res) {
   try {
     const [users] = await db.query(
-      'SELECT id, email, role, created_at, deleted_at FROM users ORDER BY created_at DESC'
+      'SELECT id, email, name, role, created_at, deleted_at FROM users ORDER BY created_at DESC'
     );
     res.json({ users });
   } catch (err) {
@@ -100,6 +100,35 @@ async function deleteResource(req, res) {
   }
 }
 
+// PATCH /api/admin/users/:id/role
+async function updateUserRole(req, res) {
+  const userId = parseInt(req.params.id, 10);
+  const { role } = req.body;
+
+  if (!['user', 'therapist', 'admin'].includes(role)) {
+    return res.status(400).json({ error: 'role must be "user", "therapist", or "admin".' });
+  }
+
+  if (userId === req.user.userId) {
+    return res.status(400).json({ error: 'You cannot change your own role.' });
+  }
+
+  try {
+    const [rows] = await db.query('SELECT id FROM users WHERE id = ? AND deleted_at IS NULL', [
+      userId,
+    ]);
+    if (rows.length === 0) {
+      return res.status(404).json({ error: 'User not found.' });
+    }
+
+    await db.query('UPDATE users SET role = ? WHERE id = ?', [role, userId]);
+    res.json({ message: `User role updated to ${role}.` });
+  } catch (err) {
+    console.error('Admin update role error:', err);
+    res.status(500).json({ error: 'Failed to update role.' });
+  }
+}
+
 // GET /api/admin/bookings
 async function listBookings(req, res) {
   try {
@@ -167,6 +196,7 @@ async function updateBooking(req, res) {
 
 module.exports = {
   listUsers,
+  updateUserRole,
   listResources,
   createResource,
   updateResource,

--- a/Server/src/controllers/resourcesController.js
+++ b/Server/src/controllers/resourcesController.js
@@ -1,21 +1,9 @@
 const db = require('../db/connection');
 
-// GET /api/resources?category=anxiety
+// GET /api/resources
 async function getResources(req, res) {
-  const { category } = req.query;
-
   try {
-    let sql = 'SELECT * FROM resources';
-    const params = [];
-
-    if (category) {
-      sql += ' WHERE category = ?';
-      params.push(category);
-    }
-
-    sql += ' ORDER BY id ASC';
-
-    const [resources] = await db.query(sql, params);
+    const [resources] = await db.query('SELECT * FROM resources ORDER BY id ASC');
     res.json({ resources });
   } catch (err) {
     console.error('Resources error:', err);

--- a/Server/src/db/migrate.js
+++ b/Server/src/db/migrate.js
@@ -168,6 +168,15 @@ async function runMigrations() {
       console.log('[migrate] Added column users.name');
     }
 
+    // Migration 011 — add categories JSON column to resources, seed from category
+    if (!(await columnExists('resources', 'categories'))) {
+      await db.query(`ALTER TABLE resources ADD COLUMN categories JSON NULL AFTER category`);
+      await db.query(
+        `UPDATE resources SET categories = JSON_ARRAY(category) WHERE categories IS NULL`
+      );
+      console.log('[migrate] Added resources.categories and seeded from category');
+    }
+
     console.log('[migrate] Schema up to date');
   } catch (err) {
     console.error('[migrate] Migration failed:', err.message);

--- a/Server/src/routes/admin.js
+++ b/Server/src/routes/admin.js
@@ -4,6 +4,7 @@ const authenticateToken = require('../middleware/auth');
 const requireAdmin = require('../middleware/requireAdmin');
 const {
   listUsers,
+  updateUserRole,
   listResources,
   createResource,
   updateResource,
@@ -31,6 +32,7 @@ router.use(authenticateToken, requireAdmin);
  *         description: Admin role required
  */
 router.get('/users', listUsers);
+router.patch('/users/:id/role', updateUserRole);
 
 /**
  * @swagger


### PR DESCRIPTION
## Summary

- **Users tab**: table of all accounts with role badge, joined date, active/deleted status; inline role dropdown to promote/demote any user (user → therapist → admin), blocked for the logged-in admin's own account
- **Bookings tab**: lists all therapy bookings across all users, split into Pending and Past sections; Confirm/Decline buttons on pending bookings (confirm locks the slot as booked, decline restores it to available)
- **Resources tab**: full CRUD — add, edit, delete resources with title, description, URL, category, and mood range fields; inline form slides in above the table
- Added `PATCH /api/admin/users/:id/role` endpoint with self-change guard
- Updated `GET /api/admin/users` to include the `name` column

## Test plan

- [ ] Log in as admin — Admin nav link visible
- [ ] Users tab: change a user's role via dropdown, verify badge updates immediately
- [ ] Bookings tab: confirm a pending booking, verify status changes to green; decline one, verify slot becomes available again in the therapist calendar
- [ ] Resources tab: add a new resource, edit it, delete it
- [ ] Verify non-admin users cannot access `/admin` (redirected to dashboard)