### PR TITLE
test: integration journey + attack-vector security suites

### DIFF
--- a/Server/src/__tests__/integration/user-journey.test.js
+++ b/Server/src/__tests__/integration/user-journey.test.js
@@ -1,0 +1,166 @@
+/**
+ * Integration Test — Full Student User Journey
+ *
+ * Exercises the complete pathway a student would take:
+ *   1. Register a new account
+ *   2. Log in with the same credentials
+ *   3. Submit a mood log and receive resources
+ *   4. List available therapy slots
+ *   5. Book a slot
+ *   6. View their bookings
+ *   7. Cancel the booking
+ *
+ * The DB is mocked (no live MySQL needed). Each step verifies that the
+ * server responds with the expected status / shape and that the JWT
+ * issued at login authenticates all subsequent calls.
+ */
+
+jest.mock('../../db/connection');
+jest.mock('bcrypt');
+
+const request = require('supertest');
+const app = require('../../app');
+const db = require('../../db/connection');
+const bcrypt = require('bcrypt');
+
+beforeAll(() => {
+  process.env.JWT_SECRET = 'integration-test-secret-32-chars-min';
+  process.env.REFRESH_SECRET = 'integration-test-refresh-secret-32';
+  process.env.NODE_ENV = 'test';
+});
+
+beforeEach(() => jest.clearAllMocks());
+
+describe('Integration — student user journey end-to-end', () => {
+  let accessToken;
+
+  test('Step 1 — register creates account and returns access token', async () => {
+    db.query
+      .mockResolvedValueOnce([[]]) // no existing user
+      .mockResolvedValueOnce([{ insertId: 42 }]); // INSERT
+    bcrypt.hash.mockResolvedValue('hashed-password');
+
+    const res = await request(app).post('/api/auth/register').send({
+      email: 'journey@cardiffmet.ac.uk',
+      password: 'Securepass1',
+    });
+
+    expect(res.status).toBe(201);
+    expect(res.body).toHaveProperty('accessToken');
+    accessToken = res.body.accessToken;
+  });
+
+  test('Step 2 — login with same credentials returns a fresh token', async () => {
+    db.query.mockResolvedValueOnce([
+      [
+        {
+          id: 42,
+          email: 'journey@cardiffmet.ac.uk',
+          password: 'hashed-password',
+          role: 'user',
+        },
+      ],
+    ]);
+    bcrypt.compare.mockResolvedValue(true);
+
+    const res = await request(app).post('/api/auth/login').send({
+      email: 'journey@cardiffmet.ac.uk',
+      password: 'Securepass1',
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('accessToken');
+    accessToken = res.body.accessToken; // overwrite with login token
+  });
+
+  test('Step 3 — log a mood and receive personalised resources', async () => {
+    db.query
+      .mockResolvedValueOnce([{ affectedRows: 1 }]) // INSERT mood_log
+      .mockResolvedValueOnce([[{ id: 1, title: 'Mindfulness Tips', min_mood: 2, max_mood: 4 }]]); // SELECT resources
+
+    const res = await request(app)
+      .post('/api/mood')
+      .set('Authorization', `Bearer ${accessToken}`)
+      .send({ rating: 3, description: 'A bit stressed about exams.' });
+
+    expect(res.status).toBe(201);
+    expect(res.body.resources).toHaveLength(1);
+  });
+
+  test('Step 4 — list available therapy slots', async () => {
+    db.query.mockResolvedValueOnce([
+      [
+        {
+          id: 7,
+          slot_date: '2026-05-01',
+          slot_time: '10:00:00',
+          status: 'available',
+          therapist_email: 't@cardiffmet.ac.uk',
+          therapist_name: 'Dr Smith',
+        },
+      ],
+    ]);
+
+    const res = await request(app)
+      .get('/api/booking/slots')
+      .set('Authorization', `Bearer ${accessToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.slots).toHaveLength(1);
+    expect(res.body.slots[0].id).toBe(7);
+  });
+
+  test('Step 5 — book a slot', async () => {
+    db.query
+      .mockResolvedValueOnce([[{ id: 7, status: 'available' }]]) // slot still available
+      .mockResolvedValueOnce([{ affectedRows: 1 }]) // UPDATE slot to pending
+      .mockResolvedValueOnce([{ insertId: 99 }]); // INSERT booking
+
+    const res = await request(app)
+      .post('/api/booking')
+      .set('Authorization', `Bearer ${accessToken}`)
+      .send({ slotId: 7 });
+
+    expect(res.status).toBe(201);
+    expect(res.body.bookingId).toBe(99);
+    expect(res.body.status).toBe('pending');
+  });
+
+  test('Step 6 — view my bookings shows the new booking', async () => {
+    db.query.mockResolvedValueOnce([
+      [
+        {
+          id: 99,
+          status: 'pending',
+          created_at: new Date().toISOString(),
+          slot_date: '2026-05-01',
+          slot_time: '10:00:00',
+          therapist_email: 't@cardiffmet.ac.uk',
+          therapist_name: 'Dr Smith',
+        },
+      ],
+    ]);
+
+    const res = await request(app)
+      .get('/api/booking/my')
+      .set('Authorization', `Bearer ${accessToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.bookings).toHaveLength(1);
+    expect(res.body.bookings[0].id).toBe(99);
+  });
+
+  test('Step 7 — cancel the booking', async () => {
+    db.query
+      .mockResolvedValueOnce([[{ id: 99, status: 'pending', slot_id: 7 }]]) // ownership check
+      .mockResolvedValueOnce([{ affectedRows: 1 }]) // DELETE booking
+      .mockResolvedValueOnce([{ affectedRows: 1 }]); // UPDATE slot back to available
+
+    const res = await request(app)
+      .delete('/api/booking/99')
+      .set('Authorization', `Bearer ${accessToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.message).toMatch(/cancelled/i);
+  });
+});

--- a/Server/src/__tests__/security/attacks.test.js
+++ b/Server/src/__tests__/security/attacks.test.js
@@ -1,0 +1,185 @@
+/**
+ * Security Test Suite — Attack-vector regression tests
+ *
+ * Demonstrates that common attack vectors are rejected by the application:
+ *   - SQL injection on /api/auth/login
+ *   - XSS payload stored in mood description
+ *   - Missing JWT
+ *   - Tampered JWT (signature mismatch)
+ *   - Expired JWT
+ *   - Forged role claim (privilege escalation attempt)
+ *   - Mass-assignment on /api/auth/register (cannot self-promote to admin)
+ */
+
+jest.mock('../../db/connection');
+jest.mock('bcrypt');
+
+const request = require('supertest');
+const jwt = require('jsonwebtoken');
+const app = require('../../app');
+const db = require('../../db/connection');
+const bcrypt = require('bcrypt');
+
+beforeAll(() => {
+  process.env.JWT_SECRET = 'security-test-secret-32-chars-or-more';
+  process.env.REFRESH_SECRET = 'security-test-refresh-secret-32-chars';
+  process.env.NODE_ENV = 'test';
+});
+
+beforeEach(() => jest.clearAllMocks());
+
+// ── SQL Injection ────────────────────────────────────────────────────────────
+
+describe('SQL injection', () => {
+  test("classic ' OR 1=1 -- payload on login is treated as a literal string", async () => {
+    // The mocked DB returns no user — proving the parameterised query treated
+    // the payload as data, not SQL.
+    db.query.mockResolvedValueOnce([[]]);
+
+    const res = await request(app).post('/api/auth/login').send({
+      email: "admin@cardiffmet.ac.uk' OR '1'='1",
+      password: "anything' OR '1'='1",
+    });
+
+    expect(res.status).toBe(401);
+    expect(res.body.error).toBe('Invalid email or password.');
+
+    // Verify mysql2 was called with the payload as a parameter, not concatenated
+    expect(db.query).toHaveBeenCalledWith(
+      expect.stringContaining('SELECT'),
+      expect.arrayContaining(["admin@cardiffmet.ac.uk' OR '1'='1"])
+    );
+  });
+
+  test('UNION-based injection on email field is rejected', async () => {
+    db.query.mockResolvedValueOnce([[]]);
+
+    const res = await request(app).post('/api/auth/login').send({
+      email: "x' UNION SELECT id, password FROM users--",
+      password: 'whatever',
+    });
+
+    expect(res.status).toBe(401);
+  });
+});
+
+// ── XSS ──────────────────────────────────────────────────────────────────────
+
+describe('XSS payload handling', () => {
+  test('mood description containing <script> is stored verbatim and not executed by the API', async () => {
+    const xssPayload = '<script>alert("xss")</script>';
+
+    db.query.mockResolvedValueOnce([{ affectedRows: 1 }]).mockResolvedValueOnce([[]]);
+
+    const token = jwt.sign(
+      { userId: 1, email: 'u@cardiffmet.ac.uk', role: 'user' },
+      process.env.JWT_SECRET,
+      { expiresIn: '15m' }
+    );
+
+    const res = await request(app)
+      .post('/api/mood')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ rating: 3, description: xssPayload });
+
+    expect(res.status).toBe(201);
+
+    // The API persists the raw string — output safety is the client's job
+    // (React auto-escapes interpolated text). Confirm the payload reached
+    // the DB exactly as posted, then assert the response is JSON, never HTML.
+    expect(db.query).toHaveBeenCalledWith(
+      expect.stringContaining('INSERT'),
+      expect.arrayContaining([xssPayload])
+    );
+    expect(res.headers['content-type']).toMatch(/application\/json/);
+  });
+});
+
+// ── JWT tampering ────────────────────────────────────────────────────────────
+
+describe('JWT validation', () => {
+  test('request without an Authorization header is rejected with 401', async () => {
+    const res = await request(app).get('/api/booking/my');
+    expect(res.status).toBe(401);
+  });
+
+  test('request with a tampered JWT (wrong signature) is rejected', async () => {
+    const valid = jwt.sign(
+      { userId: 1, email: 'u@cardiffmet.ac.uk', role: 'user' },
+      process.env.JWT_SECRET,
+      { expiresIn: '15m' }
+    );
+    // Flip the last character of the signature segment
+    const parts = valid.split('.');
+    parts[2] = parts[2].slice(0, -1) + (parts[2].slice(-1) === 'A' ? 'B' : 'A');
+    const tampered = parts.join('.');
+
+    const res = await request(app)
+      .get('/api/booking/my')
+      .set('Authorization', `Bearer ${tampered}`);
+
+    expect(res.status).toBe(403);
+  });
+
+  test('expired JWT is rejected', async () => {
+    const expired = jwt.sign(
+      { userId: 1, email: 'u@cardiffmet.ac.uk', role: 'user' },
+      process.env.JWT_SECRET,
+      { expiresIn: '-1s' } // already expired
+    );
+
+    const res = await request(app).get('/api/booking/my').set('Authorization', `Bearer ${expired}`);
+
+    expect(res.status).toBe(403);
+  });
+
+  test('JWT signed with a different secret is rejected', async () => {
+    const foreign = jwt.sign(
+      { userId: 1, email: 'attacker@evil.com', role: 'admin' },
+      'totally-different-secret',
+      { expiresIn: '15m' }
+    );
+
+    const res = await request(app).get('/api/booking/my').set('Authorization', `Bearer ${foreign}`);
+
+    expect(res.status).toBe(403);
+  });
+});
+
+// ── Privilege escalation ─────────────────────────────────────────────────────
+
+describe('Privilege escalation attempts', () => {
+  test('a student JWT cannot access admin-only endpoints', async () => {
+    const studentToken = jwt.sign(
+      { userId: 1, email: 'u@cardiffmet.ac.uk', role: 'user' },
+      process.env.JWT_SECRET,
+      { expiresIn: '15m' }
+    );
+
+    const res = await request(app)
+      .get('/api/admin/users')
+      .set('Authorization', `Bearer ${studentToken}`);
+
+    expect(res.status).toBe(403);
+  });
+
+  test('register endpoint ignores client-supplied role field', async () => {
+    db.query
+      .mockResolvedValueOnce([[]]) // no existing user
+      .mockResolvedValueOnce([{ insertId: 1 }]); // INSERT
+    bcrypt.hash.mockResolvedValue('hash');
+
+    const res = await request(app).post('/api/auth/register').send({
+      email: 'attacker@cardiffmet.ac.uk',
+      password: 'Securepass1',
+      role: 'admin', // attempt to self-promote
+    });
+
+    expect(res.status).toBe(201);
+
+    // Verify INSERT did not include 'admin' as a parameter
+    const insertCall = db.query.mock.calls.find((call) => /INSERT/.test(call[0]));
+    expect(insertCall).toBeDefined();
+    expect(insertCall[1]).not.toContain('admin');
+  });
+});


### PR DESCRIPTION
## Summary
- **`integration/user-journey.test.js`** — full student journey end-to-end: register → login → mood log → list slots → book → view bookings → cancel. 7 chained tests.
- **`security/attacks.test.js`** — 8 attack-rejection tests covering:
  - SQL injection (classic and UNION-based) on `/api/auth/login`
  - XSS payload in mood description (verifies API stores raw, returns JSON, never executes)
  - Missing JWT, tampered JWT, expired JWT, JWT signed with foreign secret
  - Student JWT against admin endpoint (privilege escalation)
  - Mass-assignment on `/api/auth/register` (cannot self-promote to admin)

Total server test count: **139** (was 124).

## Test plan
- [ ] `cd Server && npm test` — all 139 pass locally
- [ ] CI runs the full suite on PR