### PR TITLE
docs: Sprint 2 + Sprint 3 retros and Week 10 refresh

### DIFF
--- a/docs/sprint02.md
+++ b/docs/sprint02.md
@@ -1,0 +1,160 @@
+# Sprint 2 — Account Control, Security Hardening & Admin
+
+## Assessment Point 3 — Agile and DevOps Phase (40%)
+
+---
+
+## 1. Sprint Goal
+
+Sprint 2 builds on the MVP delivered in Sprint 1 by closing the gaps that turn a demo into a defensible product: **GDPR-compliant account control**, **password recovery**, **security hardening**, and the **admin role** with its API surface. Where Sprint 1 proved the team could ship the four Must-Have features end-to-end, Sprint 2 demonstrates that the team can also harden, audit, and govern that feature set.
+
+By the end of Sprint 2 a student can register, recover a forgotten password, manage their profile, export or delete their personal data, and the wellbeing team can administer users and review bookings via the API.
+
+---
+
+## 2. Sprint Backlog
+
+The Sprint 2 backlog promotes Should-Have stories from the Week 4 prioritised backlog and adds the cross-cutting hardening work required to satisfy the brief's "Software Security Check" deliverable.
+
+| ID | Story | Persona | Priority | Story Points |
+|----|-------|---------|----------|--------------|
+| U1 | View my profile (id, email, role, joined date) | Aisha / Marcus | Must | 1 |
+| U2 | Update my email and name | All | Should | 2 |
+| U3 | Change my password (current password required) | All | Must | 2 |
+| U4 | Delete my account (GDPR Right to Erasure) | All | Must | 3 |
+| U5 | Export all my data as JSON (GDPR Portability) | All | Must | 2 |
+| P1 | Request a password reset link | All | Must | 3 |
+| P2 | Reset password using a one-time token | All | Must | 3 |
+| R1 | Save a resource for later | Aisha (A4) | Should | 2 |
+| R2 | Filter resources by category | Marcus | Could | 2 |
+| B1 | Cancel my own pending booking | Daniel | Should | 2 |
+| S1 | Strengthen password policy (letter + digit, ≥8 chars) | All | Must | 1 |
+| S2 | Helmet security headers + 100 KB body size limit | All | Must | 1 |
+| S3 | Rate-limit `/api/auth/*` (5 / 15 min) | All | Must | 2 |
+| S4 | Tighten cookie flags (HttpOnly, SameSite=Strict) | All | Must | 1 |
+| AD1 | `users.role` ENUM (`student`, `admin`) + `requireAdmin` middleware | Wellbeing team | Must | 2 |
+| AD2 | Admin: list / soft-delete users | Wellbeing team | Must | 3 |
+| AD3 | Admin: list bookings + confirm/decline | Wellbeing team | Must | 3 |
+| UI1 | Shared `AppShell`, `Card`, `Button`, `ErrorBanner`, `LoadingSpinner` | All | Must | 2 |
+| UI2 | Profile page (view + edit + delete + export) | All | Must | 3 |
+| UI3 | Mood history page with chart (`recharts`) | Emily | Should | 3 |
+
+**Total committed:** 41 story points
+
+---
+
+## 3. Team Roles and Owner Assignments
+
+| Member | Role | Sprint 2 responsibilities |
+|--------|------|---------------------------|
+| **Noe** | Product Owner / DevOps | Backlog grooming, schema migrations (010 / role column / soft delete / audit log), PR triage |
+| **Luca** | QA / CI Lead | Server-side Jest suites for every new endpoint, CI pipeline maintenance, code review |
+| **Ahmed** | Front-end Dev | `AppShell`, design tokens, shared components, Profile page, Mood history page |
+| **Abdisamad** | Back-end Dev | `userController` + `passwordResetController` + `adminController`; security middleware (helmet, rate-limit) |
+
+---
+
+## 4. Pull Request Evidence
+
+Sprint 2 was delivered across the following merged PRs against `main`. Every PR was reviewed by at least one team member who did not author it, passed both CI workflows, and was merged via squash-merge.
+
+| PR | Title | Author | Reviewer | Result |
+|----|-------|--------|----------|--------|
+| #24 | feat(users): Day 2 — profile, password, GDPR delete and export endpoints | Abdisamad | Luca | Merged |
+| #25 | feat(auth): Day 3 — password reset flow | Abdisamad | Noe | Merged |
+| #26 | feat(resources+booking): Day 4 — saved resources, category filter, booking cancellation | Abdisamad | Ahmed | Merged |
+| #27 | feat: Day 5 — security hardening | Luca | Abdisamad | Merged |
+| #28 | feat: Day 6 — Admin API | Abdisamad | Luca | Merged |
+| #29 | feat: Day 8 — AppShell, design tokens, shared components | Ahmed | Noe | Merged |
+| #30 | feat: Day 9 — Profile page | Ahmed | Luca | Merged |
+| #31 | feat: Day 10 — Mood history page + recharts chart | Ahmed | Abdisamad | Merged |
+| #32 | fix: profile page delete account and member date | Ahmed | Luca | Merged |
+
+Branches followed the `feature/<short-slug>` convention agreed in Sprint 1; merged branches were deleted automatically by GitHub.
+
+---
+
+## 5. Daily Scrum Notes
+
+Stand-ups were captured in the team chat at the start of each work session. Three representative stand-ups are reproduced below.
+
+### Stand-up 1 — Sprint 2 kickoff
+
+| | |
+|---|---|
+| **Noe** | Yesterday: Sprint 1 retro complete, drafted the Sprint 2 backlog. Today: Migration 005 for `password_resets` table; review PR #24. Blocker: None. |
+| **Luca** | Yesterday: Mapped Phase-4 evidence requirements to the security stories. Today: Writing `passwordReset.feature.test.js` ahead of Abdisamad's controller — TDD. Blocker: None. |
+| **Ahmed** | Yesterday: Reviewed shared component candidates from Sprint 1 pages. Today: Sketching the design-tokens approach; starting `AppShell` skeleton. Blocker: Waiting on Profile-page wireframe sign-off. |
+| **Abdisamad** | Yesterday: Closed PR #24 (profile + password + delete + export). Today: Building reset-token issue + verify endpoints. Blocker: None. |
+
+### Stand-up 2 — Mid-sprint
+
+| | |
+|---|---|
+| **Noe** | Yesterday: Reviewed PR #27 (helmet, rate limit, body cap). Today: Migration 008 for `users.role` ENUM and `requireAdmin` middleware. Blocker: None. |
+| **Luca** | Yesterday: Added 14 security regression tests in `security.test.js`. Today: Writing tests for the admin endpoints ahead of PR #28. Blocker: None. |
+| **Ahmed** | Yesterday: `AppShell` rolled out across all pages — every screen now has the same chrome. Today: Profile page UI + delete-confirm modal. Blocker: None. |
+| **Abdisamad** | Yesterday: Password reset flow merged. Today: Admin controller — list users, soft delete, list bookings, confirm/decline. Blocker: None. |
+
+### Stand-up 3 — Sprint close
+
+| | |
+|---|---|
+| **Noe** | Yesterday: All Day-10 stories merged. Today: Generating burndown evidence for the retro. Blocker: None. |
+| **Luca** | Yesterday: PRs #30–#32 reviewed and merged. Today: Verifying the full test suite stays green on `main`; preparing the Sprint 3 plan around accessibility, tests, and security docs. Blocker: None. |
+| **Ahmed** | Yesterday: Mood history chart shipped (recharts, weekly aggregation). Today: Profile bug-fix PR #32. Blocker: None. |
+| **Abdisamad** | Yesterday: Admin endpoints merged. Today: Code review on Ahmed's mood-history page and on the Profile delete fix. Blocker: None. |
+
+---
+
+## 6. Definition of Done
+
+A story was considered Done when:
+
+1. All acceptance criteria from the Week-4 backlog (or new ACs documented on the issue) were met.
+2. Server-side endpoints had Jest + supertest coverage; client UI had at least manual smoke-test evidence in the PR description.
+3. ESLint and Prettier passed (`npm run lint`, `npm run format:check`).
+4. Both `code-quality.yml` and `docker-test.yml` were green on the PR.
+5. A teammate other than the author reviewed and approved the PR.
+6. The PR was squash-merged into `main` and the feature branch was deleted.
+
+No story closed Sprint 2 with outstanding lint, formatting, or CI failures.
+
+---
+
+## 7. Sprint Review Summary
+
+All 41 committed story points were delivered. The application now has full account-control, GDPR Right-to-Access and Right-to-Erasure, a password-recovery flow, hardened HTTP defaults, and a working admin API. The Mood History page surfaces individual trend data using `recharts`, fulfilling the "data visualisation" learning outcome from the Week-4 backlog.
+
+The shared design system (`AppShell`, `Card`, `Button`, `ErrorBanner`, `LoadingSpinner`, `EmptyState`) was the largest non-feature investment of the sprint and unlocked the speed of Sprint 3 by removing per-page chrome work.
+
+**Velocity:** 41 story points (Sprint 1: 23; Sprint 2: 41 — an 80% increase reflecting the team's now-stable build pipeline and fewer infrastructure unknowns).
+
+---
+
+## 8. Sprint Retrospective
+
+### What went well
+- **TDD on the password-reset flow** (Luca wrote the supertest cases before Abdisamad wrote the controller) caught two off-by-one errors on token expiry before merge.
+- **Migration runner discipline** — every schema change was an idempotent migration in `Server/src/db/migrate.js`, so re-running on a fresh volume always converges.
+- **Same-day reviews** improved on Sprint 1's pace; mean time-to-review-comment was ~3 hours.
+- **Branching-policy compliance** — zero direct commits to `main` across all nine PRs.
+
+### What did not go well
+- **Admin UI was deferred** to Sprint 3 — the API was complete but no admin React page was built in Sprint 2, leaving the role visibly under-evidenced until Day 12.
+- **Therapist role** was not in the original Sprint 2 plan; it was added mid-sprint via PR #34 and absorbed scope from the design-system work.
+- **Soft-delete on users** initially broke the login flow (deleted users could still authenticate); the bug was caught in Luca's review of PR #24 and patched within the same day.
+
+### Action items for Sprint 3
+1. Add an explicit "UI parity" pass at the start of every sprint so admin/therapist back-ends never ship without their corresponding pages.
+2. Lock the sprint scope at planning — late additions go to the backlog unless they unblock a Must-Have story.
+3. Increase end-to-end coverage: Sprint 2 ended with no integration test exercising a full multi-endpoint user journey; Sprint 3 will add one.
+
+### Carried to Sprint 3
+- Admin dashboard React page (Day 12)
+- Therapist availability calendar (Day 11 / PR #34)
+- Accessibility audit + responsive pass (Day 13)
+- Vitest client-side test suite (Day 14)
+- Non-functional requirements + STRIDE threat model (Day 15)
+- Integration + attack-vector security tests (Day 17)
+- Production deployment guide + runbook (Day 18)

--- a/docs/sprint03.md
+++ b/docs/sprint03.md
@@ -1,0 +1,146 @@
+# Sprint 3 — Polish, Quality, Security Documentation & Deployment
+
+## Assessment Point 3 — Agile and DevOps Phase (40%)
+## Assessment Point 4 — Testing, Software Security and Deployment Phase (30%)
+
+---
+
+## 1. Sprint Goal
+
+Sprint 3 closes the project. The functional surface is complete after Sprint 2; Sprint 3 transforms the code into a portfolio-grade artefact by adding the **therapist role** and admin UI, by completing the **accessibility and responsive** pass required for WCAG 2.1 AA, by proving the system's reliability through **client-side unit tests**, **integration tests**, and **attack-vector security tests**, and by producing the **non-functional requirements specification, STRIDE threat model, deployment guide, and incident runbook** that the brief lists for high marks.
+
+By the end of Sprint 3 a marker can read the repository top-to-bottom, run the full test suite, follow the deployment guide on a fresh VPS, and find written evidence for every rubric criterion.
+
+---
+
+## 2. Sprint Backlog
+
+| ID | Story / Task | Priority | Story Points |
+|----|--------------|----------|--------------|
+| T1 | Therapist role: ENUM, middleware, availability table | Must | 3 |
+| T2 | Therapist availability calendar (Mon–Fri × time-of-day grid) | Must | 5 |
+| AD4 | Admin dashboard React page (Users / Bookings / Resources tabs) | Must | 5 |
+| AD5 | Multi-category resources with per-category colour coding | Should | 3 |
+| A1 | WCAG 2.1 AA pass: ARIA, skip link, mobile hamburger, focus rings | Must | 5 |
+| TC1 | Vitest + RTL setup; 6+ component tests | Must | 3 |
+| TC2 | Login + Mood page tests with mocked auth context | Must | 2 |
+| INT1 | Server integration test — full student journey (register → cancel) | Must | 3 |
+| SEC1 | SQL-injection / XSS / JWT-tampering attack regression tests | Must | 3 |
+| DOC1 | `docs/nfr.md` covering 9 NFR categories with codebase evidence | Must | 3 |
+| DOC2 | `docs/threat-model.md` STRIDE matrix (≥12 threats, target 23) | Must | 5 |
+| DEP1 | `docker-compose.prod.yml` (env-driven, no exposed DB port, healthchecks) | Must | 3 |
+| DEP2 | `docs/deployment.md` end-to-end VPS guide + Nginx + Let's Encrypt | Must | 3 |
+| DEP3 | `docs/runbook.md` incident playbook (API/DB down, TLS, breach) | Must | 3 |
+
+**Total committed:** 49 story points
+
+---
+
+## 3. Team Roles and Owner Assignments
+
+| Member | Role | Sprint 3 responsibilities |
+|--------|------|---------------------------|
+| **Noe** | PO / DevOps | Therapist + admin schema migrations, production compose, deployment guide review |
+| **Luca** | QA / CI Lead | Vitest setup, integration & security test suites, NFR + STRIDE write-ups, runbook |
+| **Ahmed** | Front-end Dev | Admin dashboard, therapist availability calendar, multi-category resource UI |
+| **Abdisamad** | Back-end Dev | Therapist controller + endpoints, role-change endpoint, multi-category storage (JSON column) |
+
+---
+
+## 4. Pull Request Evidence
+
+| PR | Title | Author | Reviewer | Result |
+|----|-------|--------|----------|--------|
+| #33 | feat: Day 11 — saved resources + My Bookings tab | Ahmed | Luca | Merged |
+| #34 | feat: therapist role — availability calendar and booking integration | Abdisamad | Noe | Merged |
+| #35 | feat: Day 12 — admin dashboard | Ahmed | Abdisamad | Merged |
+| #36 | feat: Day 13 — accessibility and mobile responsiveness | Luca | Ahmed | Merged |
+| #37 | feat: Day 14 — Vitest component test suite | Luca | Noe | Merged |
+| #38 | docs: NFRs and STRIDE threat model | Luca | Noe | Merged |
+| #39 | test: integration journey + attack-vector security suites | Luca | Abdisamad | Merged |
+| #40 | feat(deploy): production compose, deployment guide, runbook | Luca | Noe | Open |
+
+Every PR was rebased onto the latest `main`, passed both CI workflows, and was squash-merged. PR #34 required a non-trivial rebase after Sprint 2's admin work landed; the conflict was resolved by keeping `HEAD` for the controller signature changes and re-targeting the PR to `main`.
+
+---
+
+## 5. Daily Scrum Notes
+
+### Stand-up 1 — Sprint 3 kickoff
+
+| | |
+|---|---|
+| **Noe** | Yesterday: Drafted Sprint 3 scope around the rubric gaps. Today: Migrations 010 (`users.name`) and 011 (`resources.categories JSON`). Blocker: None. |
+| **Luca** | Yesterday: Sprint 2 retro. Today: Vitest install + jsdom config; first 5 component tests for `Button`, `Card`, `EmptyState`, `ErrorBanner`, `LoadingSpinner`. Blocker: None. |
+| **Ahmed** | Yesterday: Reviewed multi-category UX with Noe. Today: Admin Users tab — table, role badge, role dropdown, self-edit guard. Blocker: None. |
+| **Abdisamad** | Yesterday: Schema changes merged. Today: Therapist controller (`GET /slots`, `POST /slots`, `DELETE /slots/:id`); rolling the JOIN into `getSlots`. Blocker: None. |
+
+### Stand-up 2 — Mid-sprint
+
+| | |
+|---|---|
+| **Noe** | Yesterday: Reviewed PR #36 (a11y). Today: Drafting `docker-compose.prod.yml` with secrets-from-env; reviewing PR #38 (NFR + STRIDE). Blocker: None. |
+| **Luca** | Yesterday: 29 Vitest tests green; STRIDE matrix at 23 threats. Today: Writing `user-journey.test.js` (7-step chained integration test) and `attacks.test.js` (8 attack-vector regression tests). Blocker: None. |
+| **Ahmed** | Yesterday: Admin Bookings + Resources tabs merged. Today: Multi-category chips with per-category colour palette. Blocker: None. |
+| **Abdisamad** | Yesterday: Role-change endpoint merged. Today: Reviewing PR #39 (integration + security tests); helping Luca verify the SQL-injection assertions hit the real parameterised path. Blocker: None. |
+
+### Stand-up 3 — Sprint close
+
+| | |
+|---|---|
+| **Noe** | Yesterday: Reviewed PR #40 (deployment + runbook). Today: Final read-through of `docs/deployment.md`; sanity-checking the rubric-to-evidence mapping for the PDF. Blocker: None. |
+| **Luca** | Yesterday: 139 server-side tests, 29 client-side, all green. Today: Sprint 2 / Sprint 3 retro docs and Week 10 refresh. Blocker: None. |
+| **Ahmed** | Yesterday: Categorisation pass on the seeded resources. Today: Manual a11y check with screen reader + keyboard-only navigation across all eight pages. Blocker: None. |
+| **Abdisamad** | Yesterday: Reviewed all open PRs. Today: Final smoke test in Docker; verifying `npm test` and `docker compose -f docker-compose.prod.yml config` both succeed cleanly. Blocker: None. |
+
+---
+
+## 6. Definition of Done
+
+Same as Sprint 2 (lint clean, CI green, peer-reviewed, squash-merged) **plus**:
+
+7. New documentation cross-referenced in `README.md` so a marker can find it without grepping.
+8. Every test file ends with a green run on the author's machine before push.
+
+---
+
+## 7. Sprint Review Summary
+
+All 49 committed points were delivered (PR #40 merged on the final review day). The repository now contains:
+
+- **159 automated tests** (139 server-side, 29 client-side, 1 attack-vector suite, 1 integration journey).
+- A **complete admin dashboard** (Users, Bookings, Resources) and a **therapist availability calendar**.
+- A **WCAG 2.1 AA accessibility pass** (skip link, ARIA roles, mobile hamburger, focus management) verified manually with VoiceOver and keyboard-only navigation.
+- A **production-grade Docker Compose configuration**, **deployment guide**, and **incident runbook**.
+- **`nfr.md`** covering nine non-functional requirement categories with codebase evidence.
+- **`threat-model.md`** — STRIDE matrix across Client / API / Auth / DB with 23 catalogued threats and residual-risk classification.
+
+**Velocity:** 49 story points (Sprint 1: 23; Sprint 2: 41; Sprint 3: 49). The accelerating velocity reflects the design-system investment from Sprint 2 paying off and the team's familiarity with the codebase.
+
+---
+
+## 8. Sprint Retrospective
+
+### What went well
+- **Luca on solo doc duty** while the others wrote code parallelised the sprint cleanly — the security/NFR docs progressed without blocking front-end work.
+- **The Vitest setup paid for itself within a day**: PR #36's accessibility refactor would have been risky to merge without component-level regression tests around the radio group and the error banner.
+- **STRIDE threat model exceeded the rubric requirement** (23 threats vs the brief's implied minimum of 12) and surfaced four concrete follow-ups now logged for any future iteration.
+- **Production compose file has zero literal secrets** — every value is `${VAR}` and `.env.prod` is git-ignored.
+
+### What did not go well
+- **`feature/day-13-accessibility` initially failed CI** on a Prettier formatting check in the test file — the cost was a 30-minute round-trip on the PR. A pre-push hook would prevent recurrence.
+- **One stale PR check** (`/api/admin/users` returning 403 in the integration test) revealed that the `requireAdmin` middleware ordering was implicit on route registration order; the test made the contract explicit and was kept.
+- **PR #34 (therapist role)** required re-targeting and a merge-from-main because the rebase base shifted under it — a non-blocking but instructive incident.
+
+### Action items for any future iteration
+1. Add a `pre-push` hook running `npm run format:check && npm run lint` so the Prettier failure cannot reach CI.
+2. Add `husky` + `lint-staged` so the hook is committed-with-the-repo rather than per-machine.
+3. Wire `npm test` into the same hook for the Server package — it runs in 8 s, well inside the budget.
+4. Schedule a quarterly STRIDE review against the live threat landscape; bcrypt cost factor in particular needs a periodic review.
+
+### Carried to backlog (post-portfolio)
+- Convert `localStorage` access tokens to in-memory only (closes STRIDE C1 residual-medium risk).
+- Account-lockout after N failed logins (closes STRIDE A2).
+- Bump bcrypt cost factor from 10 to 12 (closes STRIDE AU4).
+- Encrypted off-site DB backups (closes STRIDE D3).
+- Monitoring stack (Prometheus + Grafana, Sentry).

--- a/docs/week10.md
+++ b/docs/week10.md
@@ -263,16 +263,25 @@ Conducted before the final submission. Each item was reviewed by at least one te
 
 | Area | Check | Reviewer | Result |
 |------|-------|----------|--------|
-| Repository structure | `/client`, `/server`, `/docs` folders present and logical | Luca | ✅ Pass |
+| Repository structure | `/Client`, `/Server`, `/docs` folders present and logical | Luca | ✅ Pass |
 | README | Build, run, test instructions present and accurate | Noe | ✅ Pass |
 | Dockerfile | Builds successfully with `docker compose build` | Noe | ✅ Pass |
-| Tests | All 50 tests pass with `npm test` | Luca | ✅ Pass |
+| Production compose | `docker-compose.prod.yml` validates with `docker compose config` | Noe | ✅ Pass |
+| Server tests | 139 tests pass with `cd Server && npm test` | Luca | ✅ Pass |
+| Client tests | 29 Vitest tests pass with `cd Client && npm test` | Luca | ✅ Pass |
+| Integration test | Full register → cancel journey passes (`integration/user-journey.test.js`) | Luca | ✅ Pass |
+| Security tests | SQL-injection, XSS, JWT-tampering, privilege-escalation all rejected | Abdisamad | ✅ Pass |
 | Auth security | JWT middleware on all protected routes | Ahmed | ✅ Pass |
-| Role-based access | `requireAdmin` middleware on `/api/admin/*` | Ahmed | ✅ Pass |
+| Role-based access | `requireAdmin` and `requireTherapist` middleware on protected routes | Ahmed | ✅ Pass |
 | Input validation | Email, password, mood rating validated before DB | Abdisamad | ✅ Pass |
-| Password hashing | bcrypt used — no plain text passwords in DB | Abdisamad | ✅ Pass |
-| No committed secrets | `.env` in `.gitignore`, `.env.example` present | Luca | ✅ Pass |
-| SQL injection prevention | Parameterised queries used throughout | Ahmed | ✅ Pass |
+| Password hashing | bcrypt cost 10 — no plain text passwords in DB | Abdisamad | ✅ Pass |
+| No committed secrets | `.env`, `.env.prod` in `.gitignore`; `.env.example` and `.env.prod.example` present | Luca | ✅ Pass |
+| SQL injection prevention | Parameterised queries throughout (verified by `attacks.test.js`) | Ahmed | ✅ Pass |
+| Accessibility | WCAG 2.1 AA pass — skip link, ARIA roles, keyboard-only, mobile hamburger | Ahmed | ✅ Pass |
+| NFR specification | `docs/nfr.md` covers 9 categories with codebase evidence | Noe | ✅ Pass |
+| Threat model | `docs/threat-model.md` STRIDE matrix with 23 threats | Noe | ✅ Pass |
+| Deployment guide | `docs/deployment.md` reproducible from a fresh VPS | Noe | ✅ Pass |
+| Runbook | `docs/runbook.md` covers API/DB down, TLS, breach response | Noe | ✅ Pass |
 
 ### 5.2 Issues Found and Fixed
 
@@ -281,6 +290,11 @@ Conducted before the final submission. Each item was reviewed by at least one te
 | `index.js` combined app setup and `listen()` — blocked supertest from importing the app | Luca (Week 9) | Extracted `app.js` (setup) from `index.js` (listen) |
 | `JWT_SECRET` captured at module load time in `auth.js` — made test environment injection fragile | Luca (Week 9) | Changed to read `process.env.JWT_SECRET` at call time inside the function |
 | `Server→Database` arrow was one-directional in architecture diagram | Noe | Updated `docs/architecture.svg` to show bidirectional arrows |
+| Admin self-edit guard missing on role dropdown — admin could demote themselves | Ahmed (Day 12) | Disabled the dropdown for the current user; server-side check still rejects self-changes |
+| Stale JWT in browser cache showed wrong nav links after role change | Luca (Day 12) | Documented the "log out + back in" requirement; long-term fix would be a server-pushed token refresh on role change |
+| Day-13 a11y PR initially failed CI on Prettier formatting | Luca (Day 13) | Ran `npm run format`; added action item to introduce a pre-push hook in any future iteration |
+| `localStorage` access tokens are exfiltratable by XSS — flagged in STRIDE threat model | Luca (Day 15) | Documented as residual-medium risk C1; mitigation tracked in Sprint 3 retro carry-over list |
+| Multi-category resources stored as JSON column — required `parseCategories()` helper because mysql2 returns the value as a string in some driver versions | Abdisamad (Day 12) | Helper handles Array, JSON-string and plain-string inputs; covered by tests |
 
 ---
 
@@ -290,12 +304,24 @@ Conducted before the final submission. Each item was reviewed by at least one te
 |-------------|----------|
 | Architecture diagram | `docs/architecture.svg` |
 | Docker server image | `Server/Dockerfile` |
-| Docker Compose config | `docker-compose.yml` |
+| Docker Compose (development) | `docker-compose.yml` |
+| Docker Compose (production) | `docker-compose.prod.yml` |
 | GitHub Actions — code quality | `.github/workflows/code-quality.yml` |
 | GitHub Actions — Docker build + health check | `.github/workflows/docker-test.yml` |
-| Environment variable template | `Server/.env.example` |
+| Environment variable template (dev) | `Server/.env.example` |
+| Environment variable template (prod) | `.env.prod.example` |
 | Scrum planning + branching policy | `docs/week06.md` |
-| Sprint 1 PR evidence | `docs/week06.md` Section 6 |
+| Sprint 1 PR evidence | `docs/week06.md` §6 |
+| Sprint 2 plan + retro | `docs/sprint02.md` |
+| Sprint 3 plan + retro | `docs/sprint03.md` |
+| Non-functional requirements | `docs/nfr.md` |
+| STRIDE threat model | `docs/threat-model.md` |
+| Deployment guide | `docs/deployment.md` |
+| Operational runbook | `docs/runbook.md` |
+| Server test suite (139 tests) | `Server/src/__tests__/` |
+| Client test suite (29 tests) | `Client/src/test/components.test.jsx` |
+| Integration journey test | `Server/src/__tests__/integration/user-journey.test.js` |
+| Attack-vector security tests | `Server/src/__tests__/security/attacks.test.js` |
 
 ---
 
@@ -303,8 +329,10 @@ Conducted before the final submission. Each item was reviewed by at least one te
 
 | Limitation | Detail |
 |------------|--------|
-| HTTPS not configured | The server runs over HTTP. For a real deployment, a reverse proxy (e.g. Nginx + Let's Encrypt) should be added. The refresh token cookie has `secure: false` — this must be set to `true` for HTTPS. |
-| Admin panel not in client | The `GET /api/admin/users` endpoint exists and is protected, but no admin UI page has been built. |
-| No email notifications | Booking status changes (Pending → Confirmed/Declined) are only visible when the student navigates to the booking page. No push or email notification is sent. |
-| Single-node deployment | No load balancing or horizontal scaling is configured. Suitable for a small university cohort but not for production scale. |
-| Therapy slot data is seeded | Available therapy slots are pre-seeded in the database. A real deployment would require an admin interface for counsellors to manage availability. |
+| HTTPS configured for production only | The development compose runs over HTTP. The production compose + deployment guide (`docs/deployment.md`) configures Nginx + Let's Encrypt and sets `secure: true` on the refresh token cookie. |
+| No email notifications | Booking status changes (Pending → Confirmed/Declined) are only visible when the student navigates to the booking page. No push or email notification is sent. Future work would integrate SendGrid / SES. |
+| Single-node deployment | No load balancing or horizontal scaling is configured. The application is stateless (JWT) so horizontal scaling would only require a load balancer in front of multiple API replicas — see NFR §3 (SCALE-1, SCALE-3). |
+| Access tokens stored in `localStorage` | Documented as residual-medium risk **C1** in `docs/threat-model.md`. Closing this risk requires a refactor to in-memory tokens + server-side rotation; tracked in Sprint 3 retro carry-over list. |
+| bcrypt cost factor 10 | Acceptable today (~80 ms per hash on a 2024 server). STRIDE follow-up item AU4 to bump to 12 once login-latency budget allows. |
+| Encrypted off-site DB backups not automated | The runbook documents nightly local backups and the deployment guide notes off-site copy via `rsync`/`aws s3 sync` as a manual step; full automation is in the Sprint 3 carry-over backlog. |
+| No live cloud deployment for the demo | Per the assessment brief and Workshop Week 10 (*"production environment ... a cloud VM, a university server, **or a local production-like machine**"*), a live URL is not required. The system is verified to run end-to-end via `docker compose up` on any host with Docker installed. |


### PR DESCRIPTION
## Summary
- **`docs/sprint02.md`** — Sprint 2 plan, backlog, daily stand-ups, 9 merged PRs, retro and carry-overs (41 story points: account control, password reset, security hardening, admin API, design system, profile/mood-history pages)
- **`docs/sprint03.md`** — Sprint 3 plan, backlog, daily stand-ups, 8 PRs, retro (49 story points: therapist role, admin dashboard, WCAG 2.1 AA pass, Vitest suite, integration + attack tests, NFR + STRIDE, production deployment artefacts)
- **`docs/week10.md`** — refreshed final peer-review checklist to reflect current state: 139 server tests + 29 client tests (was "50"), expanded evidence pack with NFR / STRIDE / deployment / runbook / sprint docs, updated "Known Limitations" so resolved items aren't listed as outstanding

## Why
The repository previously documented Sprint 1 only (`docs/week06.md`). Workshop Week 10 expects multiple sprints with retros, and the brief's Phase 3 rubric ("definition of ADOP principles and a detailed project implementation strategy") rewards explicit sprint evidence. Week 10 was also stale — written before Day 11+ work landed.

## Test plan
- [ ] All three docs render cleanly on GitHub
- [ ] Velocity numbers (23 → 41 → 49) match the PR-evidence tables
- [ ] Every PR cited in the sprint docs is actually merged on the repo