### PR TITLE
fix: make dashboard teal and purple buttons visible

### DIFF
--- a/Client/src/components/Button.jsx
+++ b/Client/src/components/Button.jsx
@@ -14,8 +14,7 @@ const variants = {
     'bg-red-600 hover:bg-red-700 text-white shadow-sm focus-visible:ring-red-500',
   ghost:
     'bg-transparent hover:bg-slate-100 text-slate-600 focus-visible:ring-slate-400',
-  teal:
-    'bg-teal-600 hover:bg-teal-700 text-white shadow-sm focus-visible:ring-teal-500',
+  teal: 'bg-teal-600 hover:bg-teal-700 text-white shadow-sm focus-visible:ring-teal-500',
   purple:
     'bg-purple-600 hover:bg-purple-700 text-white shadow-sm focus-visible:ring-purple-500',
 };

--- a/Client/src/components/Button.jsx
+++ b/Client/src/components/Button.jsx
@@ -14,6 +14,10 @@ const variants = {
     'bg-red-600 hover:bg-red-700 text-white shadow-sm focus-visible:ring-red-500',
   ghost:
     'bg-transparent hover:bg-slate-100 text-slate-600 focus-visible:ring-slate-400',
+  teal:
+    'bg-teal-600 hover:bg-teal-700 text-white shadow-sm focus-visible:ring-teal-500',
+  purple:
+    'bg-purple-600 hover:bg-purple-700 text-white shadow-sm focus-visible:ring-purple-500',
 };
 
 const sizes = {

--- a/Client/src/pages/DashboardPage/index.jsx
+++ b/Client/src/pages/DashboardPage/index.jsx
@@ -23,8 +23,7 @@ const features = [
     label: 'View resources',
     colour: 'bg-teal-50 border-teal-100',
     iconBg: 'bg-teal-100',
-    btnVariant: 'ghost',
-    btnClass: 'bg-teal-600 hover:bg-teal-700 text-white',
+    btnVariant: 'teal',
   },
   {
     icon: '📅',
@@ -35,8 +34,7 @@ const features = [
     label: 'Book now',
     colour: 'bg-purple-50 border-purple-100',
     iconBg: 'bg-purple-100',
-    btnVariant: 'ghost',
-    btnClass: 'bg-purple-600 hover:bg-purple-700 text-white',
+    btnVariant: 'purple',
   },
 ];
 
@@ -97,7 +95,7 @@ export default function DashboardPage() {
             <p className="text-sm text-slate-600 flex-1">{f.description}</p>
             <Button
               onClick={() => navigate(f.action)}
-              className={`mt-5 w-full ${f.btnClass ?? ''}`}
+              className="mt-5 w-full"
               variant={f.btnVariant}
             >
               {f.label}


### PR DESCRIPTION
## Summary
- `ghost` variant sets `bg-transparent text-slate-600`; passing additional bg colour classes via `className` doesn't override it in Tailwind v4 without `tailwind-merge`
- Added `teal` and `purple` variants to `Button.jsx` with proper solid colours
- Updated `DashboardPage` to use the new variants directly instead of the broken ghost + className hack

## Test plan
- [ ] Open dashboard — all three feature card buttons (Log mood / View resources / Book now) are fully visible without hovering
- [ ] Colours match their card: indigo, teal, purple
- [ ] CI passes