### PR TITLE
fix: set utf8mb4 charset and replace en dashes in resource seed data

### DIFF
--- a/Client/src/components/Button.jsx
+++ b/Client/src/components/Button.jsx
@@ -14,8 +14,7 @@ const variants = {
     'bg-red-600 hover:bg-red-700 text-white shadow-sm focus-visible:ring-red-500',
   ghost:
     'bg-transparent hover:bg-slate-100 text-slate-600 focus-visible:ring-slate-400',
-  teal:
-    'bg-teal-600 hover:bg-teal-700 text-white shadow-sm focus-visible:ring-teal-500',
+  teal: 'bg-teal-600 hover:bg-teal-700 text-white shadow-sm focus-visible:ring-teal-500',
   purple:
     'bg-purple-600 hover:bg-purple-700 text-white shadow-sm focus-visible:ring-purple-500',
 };

--- a/Client/src/components/Button.jsx
+++ b/Client/src/components/Button.jsx
@@ -14,6 +14,10 @@ const variants = {
     'bg-red-600 hover:bg-red-700 text-white shadow-sm focus-visible:ring-red-500',
   ghost:
     'bg-transparent hover:bg-slate-100 text-slate-600 focus-visible:ring-slate-400',
+  teal:
+    'bg-teal-600 hover:bg-teal-700 text-white shadow-sm focus-visible:ring-teal-500',
+  purple:
+    'bg-purple-600 hover:bg-purple-700 text-white shadow-sm focus-visible:ring-purple-500',
 };
 
 const sizes = {

--- a/Client/src/pages/DashboardPage/index.jsx
+++ b/Client/src/pages/DashboardPage/index.jsx
@@ -23,8 +23,7 @@ const features = [
     label: 'View resources',
     colour: 'bg-teal-50 border-teal-100',
     iconBg: 'bg-teal-100',
-    btnVariant: 'ghost',
-    btnClass: 'bg-teal-600 hover:bg-teal-700 text-white',
+    btnVariant: 'teal',
   },
   {
     icon: '📅',
@@ -35,8 +34,7 @@ const features = [
     label: 'Book now',
     colour: 'bg-purple-50 border-purple-100',
     iconBg: 'bg-purple-100',
-    btnVariant: 'ghost',
-    btnClass: 'bg-purple-600 hover:bg-purple-700 text-white',
+    btnVariant: 'purple',
   },
 ];
 
@@ -97,7 +95,7 @@ export default function DashboardPage() {
             <p className="text-sm text-slate-600 flex-1">{f.description}</p>
             <Button
               onClick={() => navigate(f.action)}
-              className={`mt-5 w-full ${f.btnClass ?? ''}`}
+              className="mt-5 w-full"
               variant={f.btnVariant}
             >
               {f.label}

--- a/Server/src/db/schema.sql
+++ b/Server/src/db/schema.sql
@@ -1,7 +1,7 @@
 -- SEN5002 Mental Health Support App
 -- Initial Database Schema
 
-CREATE DATABASE IF NOT EXISTS mental_health_app;
+CREATE DATABASE IF NOT EXISTS mental_health_app CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 USE mental_health_app;
 
 -- Users table
@@ -100,14 +100,14 @@ CREATE TABLE IF NOT EXISTS audit_log (
 
 -- Seed resources
 INSERT INTO resources (title, description, url, category, min_mood, max_mood) VALUES
-  ('Crisis Support – Samaritans',      'Free confidential support. Call 116 123 anytime.',          'https://www.samaritans.org',             'crisis',      1, 1),
+  ('Crisis Support - Samaritans',      'Free confidential support. Call 116 123 anytime.',          'https://www.samaritans.org',             'crisis',      1, 1),
   ('NHS Urgent Mental Health Support', 'Call 111 and select option 2 for urgent support.',           'https://www.nhs.uk/mental-health',       'crisis',      1, 2),
-  ('Student Minds – Managing Stress',  'Practical tips for managing stress during exam periods.',    'https://www.studentminds.org.uk',        'anxiety',     2, 3),
-  ('Calm – Breathing Exercises',       'Guided breathing and mindfulness to reduce anxiety.',        'https://www.calm.com',                   'anxiety',     2, 4),
+  ('Student Minds - Managing Stress',  'Practical tips for managing stress during exam periods.',    'https://www.studentminds.org.uk',        'anxiety',     2, 3),
+  ('Calm - Breathing Exercises',       'Guided breathing and mindfulness to reduce anxiety.',        'https://www.calm.com',                   'anxiety',     2, 4),
   ('Cardiff Met Wellbeing Services',   'Book an appointment with the university wellbeing team.',    'https://www.cardiffmet.ac.uk/wellbeing', 'general',     1, 5),
-  ('MoodGym – Self-Help CBT',          'Free online cognitive behavioural therapy exercises.',       'https://moodgym.com.au',                 'self-help',   3, 5),
-  ('NHS – Sleep and Tiredness Tips',   'Advice on improving sleep quality and managing fatigue.',    'https://www.nhs.uk/live-well/sleep',     'self-help',   3, 5),
-  ('Headspace – Meditation',           'Guided meditation for stress relief and improved focus.',    'https://www.headspace.com',              'mindfulness', 4, 5);
+  ('MoodGym - Self-Help CBT',          'Free online cognitive behavioural therapy exercises.',       'https://moodgym.com.au',                 'self-help',   3, 5),
+  ('NHS - Sleep and Tiredness Tips',   'Advice on improving sleep quality and managing fatigue.',    'https://www.nhs.uk/live-well/sleep',     'self-help',   3, 5),
+  ('Headspace - Meditation',           'Guided meditation for stress relief and improved focus.',    'https://www.headspace.com',              'mindfulness', 4, 5);
 
 -- Seed therapy slots (3 weeks of Mon–Fri, 09–11 morning, 14–16 afternoon, 1 h each)
 INSERT INTO therapy_slots (slot_date, slot_time, time_of_day) VALUES


### PR DESCRIPTION
## Summary
- Resource names containing `–` (en dash) were rendering as `â€"` due to MySQL defaulting to latin1 charset
- Added `CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci` to `CREATE DATABASE`
- Replaced all en dashes with plain hyphens in seed data as belt-and-braces fix

## Test plan
- [ ] `docker compose down -v && docker compose up --build` to get a fresh DB with the new schema
- [ ] Open Resources page — all names display correctly with no garbled characters
- [ ] CI passes