### PR TITLE
fix: add meta description, page title and robots.txt for SEO

### DIFF
--- a/Client/index.html
+++ b/Client/index.html
@@ -4,7 +4,12 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>my-project</title>
+    <title>MindSpace — Mental Health Support</title>
+    <meta
+      name="description"
+      content="MindSpace helps Cardiff Met students track their mood, access mental health resources, and book therapy sessions in a safe and confidential space."
+    />
+    <meta name="theme-color" content="#4f46e5" />
   </head>
   <body>
     <div id="root"></div>

--- a/Client/public/robots.txt
+++ b/Client/public/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Disallow: /api/
+Allow: /


### PR DESCRIPTION
## Summary
- Fixed page title from `my-project` to `MindSpace — Mental Health Support`
- Added `<meta name="description">` to fix Lighthouse SEO "Document does not have a meta description"
- Added `<meta name="theme-color">` for mobile browser chrome
- Added `public/robots.txt` to fix Lighthouse SEO "robots.txt is not valid — 18 errors"

## Expected score improvement
SEO: 82 → 100 (both failing audits resolved)

## Test plan
- [ ] CI passes
- [ ] Browser tab shows "MindSpace — Mental Health Support"
- [ ] `localhost:5173/robots.txt` returns the file
- [ ] Lighthouse SEO score improves (run on `npm run preview` not dev server)