### PR TITLE
docs: sync project documentation to current state

### DIFF
--- a/docs/Client.md
+++ b/docs/Client.md
@@ -1,32 +1,55 @@
-# Client — Mental Health Support App
+# Client — MindSpace Frontend
 
-React + Vite frontend for the SEN5002 Personalized Mental Health Support App.
+React 19 + Vite frontend for the SEN5002 Mental Health Support App.
 
 ---
 
 ## Tech Stack
 
-- **React** — UI framework
+- **React 19** — UI library
 - **Vite** — build tool and dev server
-- **react-router-dom** — page navigation
+- **React Router v7** — client-side routing
+- **Tailwind CSS v4** — styling
+- **Recharts** — mood history line chart
+- **Vitest** + **Testing Library** — component and page tests
+- **ESLint** + **Prettier** — code quality
 
 ---
 
 ## Folder Structure
 
 ```
-client/
+Client/
+├── public/
+│   ├── robots.txt              ← SEO crawler rules
+│   └── vite.svg                ← favicon
 ├── src/
+│   ├── components/
+│   │   ├── AppShell.jsx        ← top nav, sidebar, mobile menu
+│   │   ├── Button.jsx
+│   │   ├── Card.jsx
+│   │   ├── EmptyState.jsx
+│   │   ├── ErrorBanner.jsx
+│   │   └── LoadingSpinner.jsx
 │   ├── context/
-│   │   └── AuthContext.jsx     ← JWT token storage and auth state
+│   │   ├── AuthContext.jsx     ← JWT access token + refresh cookie auth state
+│   │   ├── useAuth.js
+│   │   └── index.js
 │   ├── pages/
-│   │   ├── LoginPage.jsx       ← login and register
-│   │   ├── DashboardPage.jsx   ← home page after login
-│   │   ├── MoodPage.jsx        ← mood logging + crisis panel + resources
-│   │   ├── ResourcesPage.jsx   ← browse all resources
-│   │   └── BookingPage.jsx     ← therapy slot booking
+│   │   ├── LoginPage/          ← login, register, forgot/reset password
+│   │   ├── DashboardPage/      ← home page after login
+│   │   ├── MoodPage/           ← mood logging + crisis panel + resources
+│   │   ├── MoodHistoryPage/    ← 30-day mood trend chart
+│   │   ├── ResourcesPage/      ← browse and save all resources
+│   │   ├── BookingPage/        ← therapy slot booking
+│   │   ├── ProfilePage/        ← profile, change password, GDPR export, delete
+│   │   ├── TherapistPage/      ← therapist availability calendar
+│   │   └── AdminPage/          ← admin dashboard (users, bookings, resources)
+│   ├── test/                   ← Vitest + Testing Library tests
 │   ├── App.jsx                 ← routes and protected route logic
-│   └── main.jsx                ← app entry point
+│   ├── main.jsx                ← app entry point
+│   └── index.css               ← Tailwind base styles
+├── index.html                  ← page title, meta description, theme colour
 ├── vite.config.js
 └── package.json
 ```
@@ -36,42 +59,54 @@ client/
 ## Prerequisites
 
 - Node.js 20+
-- Server must be running (see server README)
+- Server must be running (see [`Server.md`](./Server.md))
 
 ---
 
 ## Running Locally
 
 ```bash
-cd client
+cd Client
 npm install
 npm run dev
 ```
 
 Opens at: http://localhost:5173
 
+### Production build
+
+```bash
+npm run build       # outputs to dist/
+npm run preview     # serves the build on localhost:4173
+```
+
 ---
 
 ## Pages
 
-| Route        | Page                 | Auth Required |
-|--------------|----------------------|---------------|
-| `/login`     | Login and Register   | No            |
-| `/dashboard` | Dashboard            | Yes           |
-| `/mood`      | Log Mood             | Yes           |
-| `/resources` | Browse Resources     | Yes           |
-| `/booking`   | Book Therapy Session | Yes           |
+| Route             | Page                       | Auth Required | Role           |
+|-------------------|----------------------------|---------------|----------------|
+| `/login`          | Login / Register / Reset   | No            | —              |
+| `/dashboard`      | Dashboard                  | Yes           | any            |
+| `/mood`           | Log Mood                   | Yes           | any            |
+| `/mood/history`   | 30-day mood trend          | Yes           | any            |
+| `/resources`      | Browse and save resources  | Yes           | any            |
+| `/booking`        | Book a therapy session     | Yes           | any            |
+| `/profile`        | Profile + GDPR controls    | Yes           | any            |
+| `/therapist`      | Therapist availability     | Yes           | `therapist`    |
+| `/admin`          | Admin dashboard            | Yes           | `admin`        |
 
-Any route that requires auth will redirect to `/login` if no token is present.
+Any route that requires auth will redirect to `/login` if no token is present. Role-restricted routes redirect to `/dashboard` if the user lacks the required role.
 
 ---
 
 ## How Authentication Works
 
-1. User logs in on `/login` — the server returns a JWT token
-2. The token is stored in `localStorage` via `AuthContext`
-3. Every API request to a protected endpoint sends the token in the `Authorization: Bearer <token>` header
-4. On logout the token is removed from `localStorage` and the user is redirected to `/login`
+1. User logs in on `/login` — the server returns a short-lived JWT access token + sets an `httpOnly` refresh cookie
+2. Access token is stored in memory via `AuthContext` (not `localStorage`, for XSS resilience)
+3. Every API request to a protected endpoint sends the token in `Authorization: Bearer <token>`
+4. When the access token expires, `authFetch` silently calls `/api/auth/refresh` using the cookie to get a new one
+5. On logout the access token is cleared and `/api/auth/logout` clears the refresh cookie
 
 ---
 
@@ -89,9 +124,33 @@ This is configured in `vite.config.js`. In production this would be handled by a
 
 ## Key Features
 
-- **Login / Register** — secure authentication with JWT
+- **Login / Register / Forgot password** — JWT auth with refresh cookies
 - **Mood Logging** — rate mood 1–5 with optional description
 - **Crisis Panel** — automatically shown when mood rating is 1, displays Samaritans, NHS, and Cardiff Met contacts
 - **Personalised Resources** — resources matched to mood rating returned after each log
-- **Resource Browser** — browse and save all available resources
-- **Therapy Booking** — view available slots filtered by time of day, submit booking requests
+- **Mood History** — 30-day trend chart (Recharts line graph)
+- **Resource Browser** — category filter, save-for-later
+- **Therapy Booking** — view available slots filtered by time of day, submit booking requests, view booking status
+- **Profile / GDPR** — change name/email/password, export all data as JSON, soft-delete account
+- **Therapist Calendar** — add/remove availability slots with conflict detection and past-date guards
+- **Admin Dashboard** — manage users (assign roles), CRUD resources, confirm/decline bookings
+
+---
+
+## Accessibility
+
+- Skip-to-main-content link
+- ARIA landmarks and labels throughout
+- Focus rings on all interactive elements
+- Mobile-responsive hamburger navigation
+- Lazy-loaded heavy pages
+
+Lighthouse scores on the production build: **Performance 100, Accessibility 96, Best Practices 100, SEO 100**.
+
+---
+
+## Testing
+
+```bash
+npm test            # run Vitest suite
+```

--- a/docs/GithubActions.md
+++ b/docs/GithubActions.md
@@ -1,25 +1,25 @@
-# GitHub Actions - Automated Checks
+# GitHub Actions — Automated Checks
 
 ## What's Running
 
-Three GitHub Actions workflows automatically check your code on every push:
+Two workflow files run on every push and pull request, with three jobs in total:
 
-### 1. Code Quality (ESLint)
-- Checks code quality and best practices
-- Runs on both Client and Server
-- Tests on Node 18.x and 20.x
+### Job 1: Lint & Format (`code-quality.yml` → `lint-and-format`)
+- ESLint on Client + Server
+- Prettier format check on Client + Server
+- Matrix: Node 18.x and 20.x
 
-### 2. Code Formatting (Prettier)  
-- Checks code formatting consistency
-- Runs on both Client and Server
-- Tests on Node 18.x and 20.x
+### Job 2: Server Tests (`code-quality.yml` → `test`)
+- Runs after lint-and-format succeeds
+- `npm test -- --coverage` on Server (14 suites, 164 tests)
+- Uploads `lcov-report` as a build artifact (14-day retention)
+- Node 20.x only
 
-### 3. Docker Build & Test
-- Builds Docker images from Dockerfile
-- Starts all containers (MySQL database + Express server)
-- Verifies containers run successfully
-- Tests database connection
-- Tests server health endpoint
+### Job 3: Docker Build & Test (`docker-test.yml`)
+- Builds the production Docker image
+- Starts the full docker-compose stack (API + MySQL)
+- Waits for DB schema initialisation
+- Smoke-tests `/health`, `/api/auth/register`, `/api/auth/login`
 
 ---
 
@@ -141,18 +141,23 @@ You don't need to do anything special - just push your code!
 
 ### code-quality.yml
 
-**What it does:**
-1. Checks out your code
-2. Sets up Node.js (versions 18.x and 20.x)
-3. Installs Server dependencies
-4. Runs `npm run lint` on Server
-5. Runs `npm run format:check` on Server
-6. Installs Client dependencies
-7. Runs `npm run lint` on Client
-8. Runs `npm run format:check` on Client
+Two jobs run sequentially.
 
-**Takes:** ~2-3 minutes  
-**Fails if:** Any lint errors or formatting issues found
+**`lint-and-format` job (Node 18.x + 20.x matrix):**
+1. Checks out the code
+2. Installs Server dependencies + runs `npm run lint` + `npm run format:check`
+3. Installs Client dependencies + runs `npm run lint` + `npm run format:check`
+
+**`test` job (Node 20.x, runs only if lint-and-format passes):**
+1. Checks out the code
+2. Installs Server dependencies
+3. Runs `npm test -- --coverage --coverageReporters=text --coverageReporters=lcov`
+   - Test suite: 14 suites, 164 tests, ~10s
+   - Uses ephemeral CI secrets for `JWT_SECRET` and `REFRESH_SECRET`
+4. Uploads the `lcov-report` directory as a build artifact (14-day retention)
+
+**Takes:** ~3-4 minutes total
+**Fails if:** Any lint errors, formatting issues, or test failures
 
 ### docker-test.yml
 

--- a/docs/Server.md
+++ b/docs/Server.md
@@ -1,41 +1,60 @@
-# Server — Mental Health Support App API
+# Server — MindSpace API
 
-Express.js REST API with MySQL database for the SEN5002 Personalized Mental Health Support App.
+Express 5 REST API with MySQL 8 database for the SEN5002 Mental Health Support App.
 
 ---
 
 ## Tech Stack
 
-- **Node.js** + **Express.js** — API framework
-- **MySQL** — database
-- **bcrypt** — password hashing
-- **jsonwebtoken** — JWT authentication
-- **swagger-ui-express** — API documentation
+- **Node.js 20** + **Express 5** — REST API framework
+- **MySQL 8** — relational database
+- **bcrypt** — password hashing (cost 12)
+- **jsonwebtoken** — JWT access + refresh token authentication
+- **helmet** — HTTP security headers
+- **express-rate-limit** — rate limiting
+- **cookie-parser** — refresh token cookie handling
+- **swagger-ui-express** + **swagger-jsdoc** — interactive API docs
+- **Jest** + **supertest** — test suite (14 suites, 164 tests)
 
 ---
 
 ## Folder Structure
 
 ```
-server/
+Server/
 ├── src/
 │   ├── controllers/
-│   │   ├── authController.js       ← register and login logic
-│   │   ├── moodController.js       ← mood logging and history
-│   │   ├── resourcesController.js  ← fetch resources
-│   │   └── bookingController.js    ← slots and booking requests
+│   │   ├── authController.js          ← register, login, refresh, logout
+│   │   ├── moodController.js          ← log mood + 30-day history
+│   │   ├── resourcesController.js     ← list, save, unsave resources
+│   │   ├── bookingController.js       ← slots, bookings, cancel
+│   │   ├── userController.js          ← profile, change password, GDPR export, delete
+│   │   ├── passwordResetController.js ← forgot/reset password
+│   │   ├── therapistController.js     ← therapist slots and bookings
+│   │   └── adminController.js         ← user/resource/booking admin
 │   ├── middleware/
-│   │   └── auth.js                 ← JWT authentication middleware
+│   │   ├── auth.js                    ← JWT authentication middleware
+│   │   ├── requireAdmin.js            ← admin role guard
+│   │   └── requireTherapist.js        ← therapist role guard
 │   ├── routes/
-│   │   ├── auth.js                 ← POST /api/auth/register, /login
-│   │   ├── mood.js                 ← POST /api/mood, GET /api/mood/history
-│   │   ├── resources.js            ← GET /api/resources
-│   │   └── booking.js              ← GET /api/booking/slots, POST /api/booking
+│   │   ├── auth.js                    ← /api/auth/*
+│   │   ├── mood.js                    ← /api/mood/*
+│   │   ├── resources.js               ← /api/resources/*
+│   │   ├── booking.js                 ← /api/booking/*
+│   │   ├── users.js                   ← /api/users/*
+│   │   ├── therapist.js               ← /api/therapist/*
+│   │   └── admin.js                   ← /api/admin/*
 │   ├── db/
-│   │   ├── connection.js           ← MySQL connection pool
-│   │   └── schema.sql              ← database schema and seed data
-│   ├── swagger.js                  ← Swagger/OpenAPI config
-│   └── index.js                    ← app entry point
+│   │   ├── connection.js              ← MySQL connection pool
+│   │   ├── schema.sql                 ← database schema and seed data
+│   │   └── migrate.js                 ← idempotent runtime migrations
+│   ├── utils/
+│   │   ├── validation.js              ← email/password/mood validators
+│   │   └── audit.js                   ← append-only audit log writer
+│   ├── __tests__/                     ← 14 test suites, 164 tests
+│   ├── swagger.js                     ← Swagger/OpenAPI config
+│   ├── app.js                         ← Express app setup
+│   └── index.js                       ← server entry point
 ├── Dockerfile
 ├── .dockerignore
 ├── .env.example
@@ -75,7 +94,7 @@ docker compose down
 ## Running Locally (without Docker)
 
 ```bash
-cd server
+cd Server
 cp .env.example .env      # fill in your MySQL credentials
 npm install
 npm run dev               # starts with nodemon on port 3000
@@ -97,24 +116,93 @@ DB_USER=root
 DB_PASSWORD=yourpassword
 DB_NAME=mental_health_app
 
-JWT_SECRET=your-long-random-secret
+JWT_SECRET=<min-32-char-random-string>
+REFRESH_SECRET=<min-32-char-random-string>
+NODE_ENV=development
 ```
+
+The server fails fast at boot if `JWT_SECRET` is missing or shorter than 32 chars.
 
 ---
 
 ## API Endpoints
 
-| Method | Endpoint             | Auth | Description                                     |
-|--------|----------------------|------|-------------------------------------------------|
-| GET    | `/health`            | No   | Health check                                    |
-| POST   | `/api/auth/register` | No   | Register with email + password                  |
-| POST   | `/api/auth/login`    | No   | Login, returns JWT token                        |
-| POST   | `/api/mood`          | Yes  | Log mood (1–5), returns resources + crisis flag |
-| GET    | `/api/mood/history`  | Yes  | Last 30 mood entries                            |
-| GET    | `/api/resources`     | Yes  | All mental health resources                     |
-| GET    | `/api/booking/slots` | Yes  | Available therapy slots                         |
-| POST   | `/api/booking`       | Yes  | Submit a booking request                        |
-| GET    | `/api/booking/my`    | Yes  | User's booking history                          |
+35 endpoints across 7 route files.
+
+### Auth (`/api/auth/*`)
+
+| Method | Endpoint                       | Auth | Description                          |
+|--------|--------------------------------|------|--------------------------------------|
+| POST   | `/api/auth/register`           | No   | Create an account                    |
+| POST   | `/api/auth/login`              | No   | Login, returns access + refresh JWT  |
+| POST   | `/api/auth/refresh`            | No   | Issue new access token from cookie   |
+| POST   | `/api/auth/logout`             | No   | Clear refresh cookie                 |
+| POST   | `/api/auth/forgot-password`    | No   | Request password reset email         |
+| POST   | `/api/auth/reset-password`     | No   | Submit new password with reset token |
+
+### Mood (`/api/mood/*`)
+
+| Method | Endpoint              | Auth | Description                                     |
+|--------|-----------------------|------|-------------------------------------------------|
+| POST   | `/api/mood`           | Yes  | Log mood (1–5), returns resources + crisis flag |
+| GET    | `/api/mood/history`   | Yes  | Last 30 mood entries                            |
+
+### Resources (`/api/resources/*`)
+
+| Method | Endpoint                      | Auth | Description                       |
+|--------|-------------------------------|------|-----------------------------------|
+| GET    | `/api/resources`              | Yes  | All resources, optional filters   |
+| GET    | `/api/resources/saved`        | Yes  | Resources the user has saved      |
+| POST   | `/api/resources/:id/save`     | Yes  | Save a resource                   |
+| DELETE | `/api/resources/:id/save`     | Yes  | Unsave a resource                 |
+
+### Booking (`/api/booking/*`)
+
+| Method | Endpoint              | Auth | Description                              |
+|--------|-----------------------|------|------------------------------------------|
+| GET    | `/api/booking/slots`  | Yes  | Available therapy slots                  |
+| POST   | `/api/booking`        | Yes  | Submit a booking request                 |
+| GET    | `/api/booking/my`     | Yes  | User's booking history                   |
+| DELETE | `/api/booking/:id`    | Yes  | Cancel a pending booking                 |
+
+### Users (`/api/users/*`)
+
+| Method | Endpoint                    | Auth | Description                              |
+|--------|-----------------------------|------|------------------------------------------|
+| GET    | `/api/users/me`             | Yes  | Get own profile                          |
+| PATCH  | `/api/users/me`             | Yes  | Update name / email                      |
+| PATCH  | `/api/users/me/password`    | Yes  | Change password (requires current)       |
+| DELETE | `/api/users/me`             | Yes  | Soft-delete account (GDPR erasure)       |
+| GET    | `/api/users/me/export`      | Yes  | Export all personal data as JSON (GDPR)  |
+
+### Therapist (`/api/therapist/*`) — `therapist` role
+
+| Method | Endpoint                       | Auth | Description                       |
+|--------|--------------------------------|------|-----------------------------------|
+| GET    | `/api/therapist/slots`         | Yes  | List own availability slots       |
+| POST   | `/api/therapist/slots`         | Yes  | Add a slot                        |
+| DELETE | `/api/therapist/slots/:id`     | Yes  | Remove a slot                     |
+| GET    | `/api/therapist/bookings`      | Yes  | List bookings on own slots        |
+| PATCH  | `/api/therapist/bookings/:id`  | Yes  | Confirm or decline a booking      |
+
+### Admin (`/api/admin/*`) — `admin` role
+
+| Method | Endpoint                       | Auth | Description                       |
+|--------|--------------------------------|------|-----------------------------------|
+| GET    | `/api/admin/users`             | Yes  | List all users                    |
+| PATCH  | `/api/admin/users/:id/role`    | Yes  | Change a user's role              |
+| GET    | `/api/admin/resources`         | Yes  | List all resources                |
+| POST   | `/api/admin/resources`         | Yes  | Create a resource                 |
+| PATCH  | `/api/admin/resources/:id`     | Yes  | Update a resource                 |
+| DELETE | `/api/admin/resources/:id`     | Yes  | Delete a resource                 |
+| GET    | `/api/admin/bookings`          | Yes  | List all bookings                 |
+| PATCH  | `/api/admin/bookings/:id`      | Yes  | Confirm / decline any booking     |
+
+### Health
+
+| Method | Endpoint   | Auth | Description    |
+|--------|------------|------|----------------|
+| GET    | `/health`  | No   | Health check   |
 
 Full interactive documentation available at `/api-docs` when the server is running.
 
@@ -122,25 +210,49 @@ Full interactive documentation available at `/api-docs` when the server is runni
 
 ## Database Schema
 
-Six tables:
+8 tables, charset `utf8mb4`:
 
-- **users** — email and bcrypt-hashed password
+- **users** — email, bcrypt password, role (`user` / `therapist` / `admin`), soft-delete column
 - **mood_logs** — mood entries (rating 1–5, optional description)
-- **resources** — mental health resources with mood range filters
-- **saved_resources** — resources saved by users
-- **therapy_slots** — available appointment slots
-- **bookings** — booking requests with status (pending / confirmed / declined)
+- **resources** — curated mental health resources with category and mood range
+- **saved_resources** — user ↔ resource saves
+- **therapy_slots** — therapist availability
+- **bookings** — booking requests with status (`pending` / `confirmed` / `declined`)
+- **password_resets** — SHA-256 hashed reset tokens with expiry and used-at timestamp
+- **audit_log** — append-only security event log
 
-The schema is automatically applied when the database container first starts via Docker Compose.
+Schema is applied on first DB container start via Docker Compose. Idempotent runtime migrations (`migrate.js`) reconcile column-level changes.
+
+### Seeded accounts
+
+| Role      | Email                          | Password         |
+|-----------|--------------------------------|------------------|
+| Admin     | admin@cardiffmet.ac.uk         | Admin1234!       |
+| Therapist | therapist@cardiffmet.ac.uk     | Therapist1234!   |
+
+8 mental health resources are also seeded. Therapy slots are not pre-seeded — therapists add their own through the app.
 
 ---
 
 ## Authentication
 
-Protected routes require a JWT token in the `Authorization` header:
+Protected routes require a JWT access token in the `Authorization` header:
 
 ```
 Authorization: Bearer <token>
 ```
 
-Tokens are issued on login and expire after 24 hours.
+- Access tokens expire after **15 minutes**
+- Refresh tokens are stored in an `httpOnly` + `sameSite=strict` cookie, valid for **7 days**
+- `POST /api/auth/refresh` issues a new access token using the refresh cookie
+
+---
+
+## Security
+
+- **Helmet** for HTTP security headers (CSP, HSTS, X-Frame-Options)
+- **Rate limiting** — 50 req/15 min on `/api/auth/*`, 500 req/15 min global
+- **Body size cap** — 100 KB
+- **Parameterised queries** throughout — no SQL string concatenation
+- **Audit log** — login, logout, password changes, account deletion, admin actions
+- **JWT secret enforcement** — server refuses to boot if `JWT_SECRET` < 32 chars

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -99,7 +99,7 @@ JWT_SECRET=<64-hex-char-random-string>
 REFRESH_SECRET=<64-hex-char-random-string>
 ```
 
-> **JWT_SECRET and REFRESH_SECRET must each be at least 32 characters.** The server will refuse to start if either is shorter — this is enforced at boot.
+> **JWT_SECRET must be at least 32 characters.** The server will refuse to start if it is shorter — this is enforced at boot in `app.js`. Although `REFRESH_SECRET` length is not enforced at boot, it should also be ≥ 32 chars in production.
 
 ### Step 4 — Configure the Frontend service
 
@@ -140,7 +140,7 @@ The Backend runs `Server/src/db/migrate.js` on startup, which applies the schema
 - Open `https://mindspace.lucamartinet.dev` — the React SPA loads.
 - Register a test account and log in.
 - Log a mood entry and confirm resources appear.
-- Open `https://desirable-enchantment-production-7b63.up.railway.app/api-docs/` — all 30 endpoints should be visible.
+- Open `https://desirable-enchantment-production-7b63.up.railway.app/api-docs/` — all 35 endpoints should be visible.
 
 ---
 
@@ -245,5 +245,5 @@ Before marking a deployment as production-ready:
 - [ ] Frontend `VITE_API_URL` points to the correct Backend Railway URL.
 - [ ] Custom domain CNAME resolves and Railway shows the certificate as **Active**.
 - [ ] Helmet security headers visible in browser DevTools (`Strict-Transport-Security`, `X-Content-Type-Options`, `X-Frame-Options`).
-- [ ] Swagger UI at `/api-docs/` loads and shows all 30 endpoints.
-- [ ] All 164 server tests + 29 client tests pass in CI before the deploy.
+- [ ] Swagger UI at `/api-docs/` loads and shows all 35 endpoints.
+- [ ] All 164 server tests pass in CI before the deploy.

--- a/docs/nfr.md
+++ b/docs/nfr.md
@@ -44,7 +44,7 @@ This document captures the non-functional requirements (NFRs) that constrain how
 | **SEC-1** | Passwords never stored in plain text | `bcrypt` with cost factor 12 in `authController.js`. |
 | **SEC-2** | All authenticated endpoints require a valid JWT | `requireAuth` middleware on every protected route. |
 | **SEC-3** | Refresh tokens are HTTP-only, SameSite, secure cookies | Cookie flags set in `authController.js` login response. |
-| **SEC-4** | Brute-force resistance on auth endpoints | `express-rate-limit` — 5 requests / 15 min on `/api/auth/*`. |
+| **SEC-4** | Brute-force resistance on auth endpoints | `express-rate-limit` — 50 requests / 15 min on `/api/auth/*`; 500 requests / 15 min global. |
 | **SEC-5** | OWASP-recommended security headers | `helmet()` enabled globally. |
 | **SEC-6** | SQL injection prevention | All queries use parameterised statements (`mysql2` placeholders). |
 | **SEC-7** | XSS prevention | React auto-escapes interpolated strings; no `dangerouslySetInnerHTML`. |
@@ -79,7 +79,7 @@ Compliance target: **WCAG 2.1 Level AA**.
 |----|-------------|----------|
 | **MAINT-1** | Lint-clean codebase before merging | ESLint 9 enforced on every PR via GitHub Actions. |
 | **MAINT-2** | Consistent formatting | Prettier `format:check` runs in CI. |
-| **MAINT-3** | Automated test suite executed on every PR | Jest (server) + Vitest (client) — currently 50+ tests. |
+| **MAINT-3** | Automated test suite executed on every PR | Jest (server: 14 suites, 164 tests) + Vitest (client). |
 | **MAINT-4** | Branch protection | All changes flow through reviewed PRs; CI must pass before merge. |
 | **MAINT-5** | Documented API surface | Swagger UI served at `/api-docs`. |
 | **MAINT-6** | Idempotent migration runner | `Server/src/db/migrate.js` checks `information_schema` before each ALTER. |

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -57,14 +57,14 @@ Per the brief's expectation of ≥ 12 threats, below is the full STRIDE matrix a
 | # | Category | Threat | Mitigation | Residual |
 |---|----------|--------|------------|----------|
 | A1 | **S**poofing | Attacker forges a JWT to authenticate as another user. | JWT signed with HS256 using ≥ 32-char `JWT_SECRET`; bootstrap fails fast if secret is short/missing (`app.js`). | Low |
-| A2 | **S**poofing | Credential stuffing / brute-force against `/api/auth/login`. | `express-rate-limit` — 5 requests / 15 min per IP on `/api/auth/*`. | **Medium** — distributed botnets can defeat IP-based limits; future work: account lockout + CAPTCHA. |
+| A2 | **S**poofing | Credential stuffing / brute-force against `/api/auth/login`. | `express-rate-limit` — 50 requests / 15 min per IP on `/api/auth/*`. | **Medium** — distributed botnets can defeat IP-based limits; future work: account lockout + CAPTCHA. |
 | A3 | **T**ampering | SQL injection through any user-controlled parameter. | All queries parameterised via `mysql2` placeholders — never string concatenation. Confirmed by code review. | Low |
 | A4 | **T**ampering | Mass-assignment / over-posting (e.g. POST `{role: 'admin'}` to register). | Controllers explicitly destructure expected fields only; the register endpoint never reads `role` from the request body. | Low |
 | A5 | **R**epudiation | An admin denies having changed another user's role or deleted a booking. | `audit_log` table records `user_id`, `action`, `ip`, `user_agent`, `created_at` for sensitive operations. | **Medium** — log is in the same DB it audits; offsite log shipping is out of scope. |
 | A6 | **I**nformation disclosure | Stack traces leak internals on a 500 error. | Global error handler returns generic `"Internal server error"` for status ≥ 500; full stack only in `console.error`. | Low |
 | A7 | **I**nformation disclosure | Detailed error message reveals whether an email exists ("user not found" vs "wrong password"). | Both branches return the same generic `"Invalid credentials"` response. | Low |
 | A8 | **D**oS | Attacker sends very large JSON bodies to exhaust memory. | `express.json({ limit: '100kb' })` rejects oversize payloads with HTTP 413. | Low |
-| A9 | **D**oS | Attacker floods the API with cheap requests. | Global limiter — 100 requests / 15 min per IP. | **Medium** — does not stop a Layer-7 DDoS; production deployment would sit behind Cloudflare / WAF. |
+| A9 | **D**oS | Attacker floods the API with cheap requests. | Global limiter — 500 requests / 15 min per IP. | **Medium** — does not stop a Layer-7 DDoS; production deployment would sit behind Cloudflare / WAF. |
 | A10 | **E**levation of privilege | A student calls an admin-only endpoint and is granted access. | `requireAdmin` / `requireTherapist` middleware re-validates role from the verified JWT — never trusts request body. | Low |
 | A11 | **E**levation of privilege | A user changes another user's password via `PATCH /api/users/me/password`. | Endpoint always operates on the JWT subject (`req.user.id`); never accepts a target user id. Current password is required. | Low |
 
@@ -75,7 +75,7 @@ Per the brief's expectation of ≥ 12 threats, below is the full STRIDE matrix a
 | AU1 | **S**poofing | Refresh token theft via XSS. | Refresh token stored in HTTP-only, SameSite=strict, secure cookie — unreachable from JS. | Low |
 | AU2 | **T**ampering | Replay of an old / leaked access token after logout. | Access tokens are short-lived (15 min); refresh tokens are revoked on logout / password change. | **Medium** — within the 15-min window a leaked access token is usable; rotation on each refresh is in place. |
 | AU3 | **R**epudiation | User claims they did not log in from a particular location. | `audit_log` records IP + user agent on every login. | Low |
-| AU4 | **I**nformation disclosure | Password hashes leak from a DB dump. | `bcrypt` cost factor 10 — brute force is computationally expensive even with the hash. | **Medium** — cost should be raised to 12+ as hardware improves. |
+| AU4 | **I**nformation disclosure | Password hashes leak from a DB dump. | `bcrypt` cost factor 12 — each guess is ~4× slower than cost 10, frustrating offline brute force. | Low |
 | AU5 | **E**levation of privilege | An admin's password reset token is intercepted. | Tokens are stored as SHA-256 hashes in `password_resets`; one-time use; expire after 30 minutes. | Low |
 
 ### 2.4 Database (MySQL 8)
@@ -93,15 +93,14 @@ Per the brief's expectation of ≥ 12 threats, below is the full STRIDE matrix a
 
 - **Total threats catalogued:** 23 (target was ≥ 12)
 - **High residual risk:** 1 (DB backup confidentiality — outside application scope)
-- **Medium residual risk:** 6 (mostly require infrastructure-level controls or advanced anti-abuse)
-- **Low residual risk:** 16
+- **Medium residual risk:** 5 (mostly require infrastructure-level controls or advanced anti-abuse)
+- **Low residual risk:** 17
 
 ### Priority follow-up actions
 
 1. Move access tokens from `localStorage` to in-memory only + secure cookie pattern (closes C1).
 2. Add account lockout after N failed logins to harden against distributed brute-force (closes A2).
-3. Bump bcrypt cost factor to 12 once average login latency budget allows (closes AU4).
-4. Document and automate encrypted DB backups in the deployment guide (closes D3).
+3. Document and automate encrypted DB backups in the deployment guide (closes D3).
 
 ---
 


### PR DESCRIPTION
## Summary
Audit pass over the evergreen docs in `/docs` to bring them in line with the current code.

## Changes
- **Server.md** — full rewrite. All 35 endpoints, 8 tables, every controller/route, seed accounts, 50/500 rate limits, bcrypt 12, JWT 15min/7d
- **Client.md** — full rewrite. All 9 pages and routes, role-protected paths, refresh-cookie auth pattern, robots.txt, Lighthouse scores
- **GithubActions.md** — correct workflow count (2 files / 3 jobs); document the Jest test job that was previously omitted
- **nfr.md** — SEC-4 5/100 -> 50/500 req/15min; MAINT-3 50+ -> 164 tests
- **threat-model.md** — A2 5 -> 50 req, A9 100 -> 500 req, AU4 bcrypt 10 -> 12 (residual now Low); update summary counts; remove obsolete follow-up #3
- **deployment.md** — 30 -> 35 endpoints; correct JWT_SECRET-only enforcement claim; drop stale 29-client-tests reference

No code changes — docs only.